### PR TITLE
WIP: CAP Gallery Page

### DIFF
--- a/src/gallery/index.html
+++ b/src/gallery/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>Caselaw Access Project</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<meta name="author" content="Your name" />
+		<meta name="description" content="Explore American Caselaw" />
+		<meta property="og:title" content="Caselaw Access Project" />
+		<meta property="og:description" content="Explore American Caselaw" />
+		<meta property="og:url" content="https://case.law/" />
+		<meta property="og:type" content="article" />
+		<meta property="og:site_name" content="Caselaw Access Projects" />
+
+		<link href="/css/global.css" rel="stylesheet" />
+		<script type="module" src="/templates/cap-gallery-page.js"></script>
+	</head>
+	<body>
+		<cap-gallery-page></cap-gallery-page>
+	</body>
+</html>

--- a/src/templates/cap-gallery-page.js
+++ b/src/templates/cap-gallery-page.js
@@ -1,0 +1,48 @@
+import { LitElement, html } from "../lib/lit.js";
+import "../components/cap-nav.js";
+import "../components/cap-page-header.js";
+import "../components/cap-footer.js";
+import "../components/cap-anchor-list.js";
+import "../components/cap-media-list.js";
+import "../components/cap-contributor-list.js";
+import "../components/cap-gallery-item.js";
+
+import { anchorLinks } from "../data/aboutSidebarLinks.js";
+
+export class CapGalleryPage extends LitElement {
+	// Turn Shadow DOM off
+	// Generally discouraged: https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot
+	createRenderRoot() {
+		return this;
+	}
+
+	render() {
+		return html`
+			<cap-nav></cap-nav>
+			<main id="main" class="l-interiorPage">
+				<header class="u-bg-gray-500 u-col-span-full">
+					<cap-page-header heading="About">
+						<p class="u-text-white u-text-serif">
+							The Caselaw Access Project (“CAP”) expands public access to U.S.
+							law. Our goal is to make all published U.S. court decisions freely
+							available to the public online, in a consistent format, digitized
+							from the collection of the Harvard Law School Library.
+						</p>
+					</cap-page-header>
+				</header>
+				<aside class="u-w-fit u-sm-hidden">
+					<cap-anchor-list .data=${anchorLinks}></cap-anchor-list>
+				</aside>
+				<article class="c-article u-bg-beige">
+					<cap-gallery-item
+						title="Modeling the Caselaw Access Project"
+						description="Article by Felix B. Chang, Erin McCabe, and James Lee, 22 Nevada Law Journal (2022)"
+						link="/test.html"
+					></cap-gallery-item>
+				</article>
+			</main>
+			<cap-footer></cap-footer>
+		`;
+	}
+}
+customElements.define("cap-gallery-page", CapGalleryPage);

--- a/src/templates/cap-gallery-page.js
+++ b/src/templates/cap-gallery-page.js
@@ -9,6 +9,15 @@ import "../components/cap-gallery-item.js";
 
 import { anchorLinks } from "../data/aboutSidebarLinks.js";
 
+const testData = [
+	{
+		title: "Modeling the Caselaw Access Project",
+		description:
+			"Article by Felix B. Chang, Erin McCabe, and James Lee, 22 Nevada Law Journal (2022)",
+		link: "/test.html",
+	},
+];
+
 export class CapGalleryPage extends LitElement {
 	// Turn Shadow DOM off
 	// Generally discouraged: https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot
@@ -34,11 +43,16 @@ export class CapGalleryPage extends LitElement {
 					<cap-anchor-list .data=${anchorLinks}></cap-anchor-list>
 				</aside>
 				<article class="c-article u-bg-beige">
-					<cap-gallery-item
-						title="Modeling the Caselaw Access Project"
-						description="Article by Felix B. Chang, Erin McCabe, and James Lee, 22 Nevada Law Journal (2022)"
-						link="/test.html"
-					></cap-gallery-item>
+					<h2>Test Section</h2>
+					${testData.map((item) => {
+						return html`
+							<cap-gallery-item
+								title=${item.title}
+								description=${item.description}
+								link=${item.link}
+							></cap-gallery-item>
+						`;
+					})}
 				</article>
 			</main>
 			<cap-footer></cap-footer>


### PR DESCRIPTION
# What this does (right now)
Adds a placeholder gallery page, with some dummy data, for helpful context!

## Summary 
- Adds gallery.html
- Adds cap-gallery-page page-level template (no Shadow DOM, purely for templating purposes)

## Notes 
- testData is included as an example to show how we could iterate on a series of arrays to output the links for each gallery section. 
- The gallery page right now has placeholder content pulled from the About page, to show the gallery items in context. I think if we decided we no longer needed a sidebar, we could always get rid of it!