### PR TITLE
Changes needed for css, js, font, and image paths to work with GitHub pages deployment

### DIFF
--- a/components/cap-decorated-header.js
+++ b/components/cap-decorated-header.js
@@ -43,7 +43,7 @@ export class CapDecoratedHeader extends LitElement {
 
 			.heading--smallWedge::before {
 				content: "";
-				background: url("/images/wedge.svg") no-repeat;
+				background: url("../images/wedge.svg") no-repeat;
 				position: absolute;
 				top: 50%;
 				left: -30px;
@@ -54,7 +54,7 @@ export class CapDecoratedHeader extends LitElement {
 
 			.heading--largeWedge::before {
 				content: "";
-				background: url("/images/wedge.svg") no-repeat;
+				background: url("../images/wedge.svg") no-repeat;
 				position: absolute;
 				top: 50%;
 				left: -30px;

--- a/components/cap-decorated-header.js
+++ b/components/cap-decorated-header.js
@@ -43,7 +43,7 @@ export class CapDecoratedHeader extends LitElement {
 
 			.heading--smallWedge::before {
 				content: "";
-				background: url("../images/wedge.svg") no-repeat;
+				background: url("./images/wedge.svg") no-repeat;
 				position: absolute;
 				top: 50%;
 				left: -30px;
@@ -54,7 +54,7 @@ export class CapDecoratedHeader extends LitElement {
 
 			.heading--largeWedge::before {
 				content: "";
-				background: url("../images/wedge.svg") no-repeat;
+				background: url("./images/wedge.svg") no-repeat;
 				position: absolute;
 				top: 50%;
 				left: -30px;

--- a/css/fonts.css
+++ b/css/fonts.css
@@ -3,11 +3,11 @@
 	font-weight: 200 900;
 	font-style: normal;
 	font-stretch: normal;
-	src: url("/fonts/source-serif/SourceSerif4Variable-Roman.ttf.woff2")
+	src: url("../fonts/source-serif/SourceSerif4Variable-Roman.ttf.woff2")
 			format("woff2-variations"),
-		url("/fonts/source-serif/SourceSerif4Variable-Roman.ttf.woff")
+		url("../fonts/source-serif/SourceSerif4Variable-Roman.ttf.woff")
 			format("woff-variations"),
-		url("/fonts/source-serif/SourceSerif4Variable-Roman.ttf")
+		url("../fonts/source-serif/SourceSerif4Variable-Roman.ttf")
 			format("truetype-variations");
 }
 
@@ -16,11 +16,11 @@
 	font-weight: 200 900;
 	font-style: italic;
 	font-stretch: normal;
-	src: url("/fonts/source-serif/SourceSerif4Variable-Italic.ttf.woff2")
+	src: url("../fonts/source-serif/SourceSerif4Variable-Italic.ttf.woff2")
 			format("woff2-variations"),
-		url("/fonts/source-serif/SourceSerif4Variable-Italic.ttf.woff")
+		url("../fonts/source-serif/SourceSerif4Variable-Italic.ttf.woff")
 			format("woff-variations"),
-		url("/fonts/source-serif/SourceSerif4Variable-Italic.ttf")
+		url("../fonts/source-serif/SourceSerif4Variable-Italic.ttf")
 			format("truetype-variations");
 }
 
@@ -29,10 +29,10 @@
 	font-weight: 200 900;
 	font-style: normal;
 	font-stretch: normal;
-	src: url("/fonts/source-sans-3/SourceSans3VF-Upright.ttf.woff2")
+	src: url("../fonts/source-sans-3/SourceSans3VF-Upright.ttf.woff2")
 			format("woff2"),
-		url("/fonts/SourceSans3VF-Upright.ttf.woff") format("woff"),
-		url("/fonts/SourceSans3VF-Upright.ttf") format("truetype");
+		url("../fonts/SourceSans3VF-Upright.ttf.woff") format("woff"),
+		url("../fonts/SourceSans3VF-Upright.ttf") format("truetype");
 }
 
 @font-face {
@@ -48,9 +48,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-it-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-it-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-it-webfont.woff") format("woff");
+		url("../fonts/source-code-pro/sourcecodepro-it-webfont.woff") format("woff");
 	font-weight: 400;
 	font-style: italic;
 }
@@ -58,9 +58,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-light-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-light-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-light-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-light-webfont.woff")
 			format("woff");
 	font-weight: 300;
 	font-style: normal;
@@ -69,9 +69,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-lightit-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-lightit-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-lightit-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-lightit-webfont.woff")
 			format("woff");
 	font-weight: 300;
 	font-style: italic;
@@ -80,9 +80,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-medium-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-medium-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-medium-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-medium-webfont.woff")
 			format("woff");
 	font-weight: 500;
 	font-style: normal;
@@ -91,9 +91,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-mediumit-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-mediumit-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-mediumit-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-mediumit-webfont.woff")
 			format("woff");
 	font-weight: 500;
 	font-style: italic;
@@ -102,9 +102,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-regular-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-regular-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-regular-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-regular-webfont.woff")
 			format("woff");
 	font-weight: 400;
 	font-style: normal;
@@ -113,9 +113,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-semibold-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-semibold-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-semibold-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-semibold-webfont.woff")
 			format("woff");
 	font-weight: 600;
 	font-style: normal;
@@ -124,9 +124,9 @@
 @font-face {
 	font-display: swap;
 	font-family: "source-code";
-	src: url("/fonts/source-code-pro/sourcecodepro-semiboldit-webfont.woff2")
+	src: url("../fonts/source-code-pro/sourcecodepro-semiboldit-webfont.woff2")
 			format("woff2"),
-		url("/fonts/source-code-pro/sourcecodepro-semiboldit-webfont.woff")
+		url("../fonts/source-code-pro/sourcecodepro-semiboldit-webfont.woff")
 			format("woff");
 	font-weight: 600;
 	font-style: italic;
@@ -135,7 +135,7 @@
 @font-face {
 	font-display: swap;
 	font-family: "Libre Baskerville";
-	src: url("/fonts/LibreBaskerville-Regular.woff") format("woff");
+	src: url("../fonts/LibreBaskerville-Regular.woff") format("woff");
 	font-weight: 300;
 	font-style: normal;
 }
@@ -143,8 +143,8 @@
 @font-face {
 	font-display: swap;
 	font-family: "titillium";
-	src: url("/fonts/titilliumweb-bold-webfont.woff2") format("woff2"),
-		url("/fonts/titilliumweb-bold-webfont.woff") format("woff");
+	src: url("../fonts/titilliumweb-bold-webfont.woff2") format("woff2"),
+		url("../fonts/titilliumweb-bold-webfont.woff") format("woff");
 	font-weight: 700;
 	font-style: normal;
 }
@@ -152,8 +152,8 @@
 @font-face {
 	font-display: swap;
 	font-family: "titillium";
-	src: url("/fonts/titilliumweb-semibold-webfont.woff2") format("woff2"),
-		url("/fonts/titilliumweb-semibold-webfont.woff") format("woff");
+	src: url("../fonts/titilliumweb-semibold-webfont.woff2") format("woff2"),
+		url("../fonts/titilliumweb-semibold-webfont.woff") format("woff");
 	font-weight: 600;
 	font-style: normal;
 }
@@ -161,8 +161,8 @@
 @font-face {
 	font-display: swap;
 	font-family: "titillium";
-	src: url("/fonts/titilliumweb-regular-webfont.woff2") format("woff2"),
-		url("/fonts/titilliumweb-regular-webfont.woff") format("woff");
+	src: url("../fonts/titilliumweb-regular-webfont.woff2") format("woff2"),
+		url("../fonts/titilliumweb-regular-webfont.woff") format("woff");
 	font-weight: 400;
 	font-style: normal;
 }

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
 		<meta property="og:type" content="article" />
 		<meta property="og:site_name" content="Caselaw Access Projects" />
 
-		<link href="/css/global.css" rel="stylesheet" />
-		<script type="module" src="/components/cap-map.js"></script>
-		<script type="module" src="/components/cap-nav.js"></script>
-		<script type="module" src="/components/cap-stats.js"></script>
-		<script type="module" src="/components/cap-section-highlight.js"></script>
-		<script type="module" src="/components/cap-contact.js"></script>
-		<script type="module" src="/components/cap-footer.js"></script>
+		<link href="css/global.css" rel="stylesheet" />
+		<script type="module" src="components/cap-map.js"></script>
+		<script type="module" src="components/cap-nav.js"></script>
+		<script type="module" src="components/cap-stats.js"></script>
+		<script type="module" src="components/cap-section-highlight.js"></script>
+		<script type="module" src="components/cap-contact.js"></script>
+		<script type="module" src="components/cap-footer.js"></script>
 	</head>
 	<body>
 		<cap-nav></cap-nav>


### PR DESCRIPTION
### **What's the change?**

Change was to update the folder locations of the JS, CSS, font, and image source paths. 

### **Why was it needed?**

GitHub pages deployment was successful however some of the assets mentioned above were not navigatable by the app resulting in 404 errors in the console. 

### **Before:**

<img width="1701" alt="Screenshot 2024-01-17 at 12 14 09 PM" src="https://github.com/harvard-lil/capstone-static/assets/156083782/e92d1383-27d8-400d-8d4d-f5729d5a31eb">

### **After:**

<img width="1705" alt="Screenshot 2024-01-17 at 12 15 25 PM" src="https://github.com/harvard-lil/capstone-static/assets/156083782/c4cfe232-1bcc-4d8b-af46-6f09e7b054a2">
