### PR TITLE
Add `run.py` for serving locally without Visual Studio Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5501,
+    "liveServer.settings.root": "/",
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# capstone-static
+
+The Caselaw Access Project was a large-scale digitization project hosted by the [Harvard Law School Library Innovation Lab](http://lil.law.harvard.edu/).
+
+This is a static, archival port of the [website originally hosted at case.law](https://github.com/harvard-lil/capstone), which served court opinions and an accompanying suite of tools to users in a variety of formats.
+
+This repository does not itself contain case data: visit the [website](https://case.law) to browse and download case data.
+
+
+---
+
+## Summary
+- [Local Development](#local-development)
+- [Tests and linting](#tests-and-linting)
+- [Deployment](#deployment)
+
+
+---
+
+## Local Development
+
+This project has no external dependencies: point any web server at the project directory, and you should be good to go!
+
+
+### Python
+
+For convenience, `run.py`, a simple wrapper for python's `http.server` is provided. Run `python3 run.py` and visit `http://127.0.0.1:5501`in your web browser. Or, run `python3 run.py --help` for a full list of flags and options.
+
+
+### VS Code's "LiveServer" Plugin
+
+[Visual Studio Code](https://code.visualstudio.com/) users may prefer to install the [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) extension.
+
+A basic configuration is included in `.vscode`. See Github for a [complete list of options](https://github.com/ritwickdey/vscode-live-server/blob/HEAD/docs/settings.md).
+
+
+[👆 Back to the summary](#summary)
+
+---
+
+## Tests and Linting
+(todo)
+
+
+[👆 Back to the summary](#summary)
+
+---
+
+## Deployment
+(todo)
+
+
+[👆 Back to the summary](#summary)

--- a/run.py
+++ b/run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', '*')
+        self.send_header('Access-Control-Allow-Headers', '*')
+        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+
+if __name__ == '__main__':
+    import argparse
+    import os
+    import sys
+
+    PORT = 5501
+    DIRECTORY = os.getcwd()
+
+    parser = argparse.ArgumentParser(description="A wrapper for http.server with generous CORS headers")
+    parser.add_argument("port", nargs='?', type=int, default=PORT, help=f"specify alternate port (default: {PORT})")
+    parser.add_argument("--bind", "-b", metavar='ADDRESS', help="specify alternate bind address (default: all interfaces)")
+    parser.add_argument("--directory", "-d", default=DIRECTORY, metavar='DIRECTORY', help="specify alternate directory (default: current directory)")
+    args = parser.parse_args()
+
+    os.chdir(args.directory)
+    test(CORSRequestHandler, HTTPServer, port=args.port, bind=args.bind)
+
+


### PR DESCRIPTION
This PR adds a tiny utility script, a wrapper for python's `http.server` that sets generous CORS headers, for developer convenience.

By default, it runs on port 5501, to match the port specified in `.vscode/settings.json`, but the port and address are fully configurable:

```% python3 run.py --help                    
usage: run.py [-h] [--bind ADDRESS] [--directory DIRECTORY] [port]

A wrapper for http.server with generous CORS headers

positional arguments:
  port                  specify alternate port (default: 5501)

options:
  -h, --help            show this help message and exit
  --bind ADDRESS, -b ADDRESS
                        specify alternate bind address (default: all interfaces)
  --directory DIRECTORY, -d DIRECTORY
                        specify alternate directory (default: current directory)
```

It also adds just a hint of a README, in order to document this script's usage, alongside instructions for Visual Studio Code users.