### PR TITLE
Use Github Actions for more control over Github Pages deployments

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Only upload the repo's `src` directory
+          path: './src'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
https://github.com/harvard-lil/capstone-static/pull/12 broke our Github Pages build, as expected.

But I did _not_ expect that the dropdown for selecting where to build from only has two options: `/ (root)` and `/docs`. I thought you could pick an arbitrary subdirectory. I was wrong!

To build from an arbitrary subdirectory, you have to use the new "Github Actions" strategy, coupled with a config file. I made the switch using the Github "Settings" UI, and it generated this config file and PR for me! Hence why this is from a branch on the main repo, and not from my fork.

I _think_ if we merge, we should be good to go.