### PR TITLE
update live server base path, update nav links to go one folder up into src folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "liveServer.settings.port": 5501,
-    "liveServer.settings.root": "/src",
+    "liveServer.settings.root": "./src",
 }

--- a/src/data/nav.js
+++ b/src/data/nav.js
@@ -1,30 +1,30 @@
 export const navLinks = [
 	{
 		name: "Caselaw",
-		path: "/caselaw/",
+		path: "../caselaw/",
 	},
 	{
 		name: "Docs",
-		path: "/docs/",
+		path: "../docs/",
 	},
 	{
 		name: "Gallery",
-		path: "/gallery/",
+		path: "../gallery/",
 	},
 	{
 		name: "About",
-		path: "/about/",
+		path: "../about/",
 	},
 ];
 
 export const legalLinks = [
 	{
 		name: "Terms",
-		path: "/terms/",
+		path: "../terms/",
 	},
 	{
 		name: "Privacy",
-		path: "/privacy/",
+		path: "../privacy/",
 	},
 	{
 		name: "Accessibility",


### PR DESCRIPTION
### What is the change?

Update vs code live server base path to read from root level src folder, update nav links to go one folder up into src folder to find assets

### Why is it needed?

Without the live server base path change, the settings json looks at the same directory level and can't find the index html. For nav links, we need to navigate one folder up to leave the data folder. I updated all the nav links and the legal links for now for consistency. When we have content for those pages as well (similar to about page), and if they are placed in a different directory, then we can update the paths accordingly. 