### PR TITLE
Add page titles for About and Caselaw pages.

### DIFF
--- a/src/about/index.html
+++ b/src/about/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>Caselaw Access Project</title>
+		<title>About | Caselaw Access Project</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="noindex" />

--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>Caselaw Access Project</title>
+		<title>Caselaw | Caselaw Access Project</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="noindex" />


### PR DESCRIPTION
This trivial PR adds unique titles for the "About" and "Caselaw" pages.

It does not attempt the more complex task of updating the page title as folks actually browse the caselaw, which probably wants to be done as a side effect during those "pages" `render` step. 