### PR TITLE
[ENG-549] pull full name of reporter jurisdiction from ReportersMetadata.json

### DIFF
--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -3,7 +3,7 @@ export const fetchJurisdictionsData = async (callback) => {
 	const data = await fetchJson(url);
 	const jurisdictions = {};
 	data.forEach((element) => {
-		const jurisdiction = element.jurisdictions[0].name;
+		const jurisdiction = element.jurisdictions[0].name_long;
 		if (!jurisdictions[jurisdiction]) {
 			jurisdictions[jurisdiction] = [];
 		}


### PR DESCRIPTION
### What is the change?

The change is to pull the `name_long` attribute from ReportersMetadata.json instead of the `name` attribute.

### Why was it made?

The change is needed so we can build the left-hand side navigation menu similar to what we currently have on https://cite.case.law/.

**Before:**

![image](https://github.com/harvard-lil/capstone-static/assets/156083782/cddfd7cf-58d2-42e5-add1-656ac7db3fe6)

**After:**

![image](https://github.com/harvard-lil/capstone-static/assets/156083782/edac8f4f-170f-45b7-b190-8c0a380ebb6a)
