### PR TITLE
Add jurisdiction page content and styles

### DIFF
--- a/src/components/cap-caselaw-layout.js
+++ b/src/components/cap-caselaw-layout.js
@@ -1,0 +1,30 @@
+import { LitElement, html, css } from "../lib/lit.js";
+import { baseStyles } from "../lib/wc-base.js";
+
+export class CapCaselawLayout extends LitElement {
+	static styles = [
+		baseStyles,
+		css`
+			.caselawContent {
+				display: grid;
+				grid-template-columns: repeat(4, 1fr);
+
+				@media (min-width: 65rem) {
+					max-width: 80%;
+					margin-inline: auto;
+					box-shadow: 0 0 27px 0 rgba(222, 222, 230, 0.46);
+				}
+			}
+		`,
+	];
+
+	render() {
+		return html`
+			<main id="main" class="caselawContent">
+				<slot></slot>
+			</main>
+		`;
+	}
+}
+
+customElements.define("cap-caselaw-layout", CapCaselawLayout);

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -1,5 +1,4 @@
 import { html, LitElement } from "../lib/lit.js";
-
 import "./cap-volume.js";
 import "./cap-case.js";
 import "./cap-jurisdictions.js";

--- a/src/components/cap-decorated-header.js
+++ b/src/components/cap-decorated-header.js
@@ -21,11 +21,11 @@ export class CapDecoratedHeader extends LitElement {
 				line-height: 1.125;
 			}
 
-			.heading--white {
+			.heading--light {
 				color: var(--color-white);
 			}
 
-			.heading--black {
+			.heading--dark {
 				color: var(--color-gray-600);
 			}
 
@@ -68,7 +68,7 @@ export class CapDecoratedHeader extends LitElement {
 	constructor() {
 		super();
 		this.icon = "smallWedge";
-		this.theme = "white";
+		this.theme = "light";
 		this.headingLevel = "h2";
 		this.size = "medium";
 	}

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -110,7 +110,7 @@ export default class CapJurisdictions extends LitElement {
 			<cap-caselaw-layout>
 				<header class="jurisdictions__header">
 					<cap-page-header heading="Read Caselaw" theme="black" icon="none">
-						<p class="jurisdicrions__description">
+						<p class="jurisdictions__description">
 							Browse all volumes of the Caselaw Access Project below.
 						</p>
 					</cap-page-header>

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -1,5 +1,8 @@
 import { LitElement, html, css } from "../lib/lit.js";
 import { fetchJurisdictionsData } from "../lib/data.js";
+import { baseStyles } from "../lib/wc-base.js";
+import "../components/cap-page-header.js";
+import "../components/cap-caselaw-layout.js";
 
 export default class CapJurisdictions extends LitElement {
 	static properties = {
@@ -11,6 +14,92 @@ export default class CapJurisdictions extends LitElement {
 		this.jurisdictionsData = [];
 	}
 
+	static styles = [
+		baseStyles,
+
+		css`
+			p,
+			ul {
+				font-family: var(--font-sans-text);
+
+				@media (min-width: 35rem) {
+					font-size: var(--font-size-175);
+				}
+			}
+
+			ul {
+				padding: 0;
+			}
+
+			li {
+				list-style-type: none;
+			}
+
+			a:link,
+			a:visited,
+			a:hover,
+			a:active {
+				text-decoration: none;
+				color: var(--color-blue-400);
+
+				&:hover {
+					color: var(--color-blue-500);
+					text-decoration: underline;
+				}
+			}
+
+			.jurisdictions__header {
+				grid-column: 1 / -1;
+				border-bottom: 1px solid var(--color-gray-200);
+			}
+
+			.jurisdictions__description {
+				font-family: var(--font-serif);
+			}
+
+			.jurisdictions__main {
+				grid-column: 1 / -1;
+				padding-inline: var(--spacing-500);
+				padding-block-start: var(--spacing-300);
+				padding-block-end: var(--spacing-550);
+
+				@media (min-width: 60rem) {
+					grid-column: 2 / -1;
+				}
+			}
+
+			.jurisdiction + .jurisdiction {
+				margin-block-start: var(--spacing-300);
+			}
+
+			.jurisdiction__heading {
+				font-weight: 400;
+				font-size: var(--font-size-250);
+				position: relative;
+			}
+
+			@media (min-width: 60rem) {
+				.jurisdiction__heading::before {
+					content: "§";
+					color: var(--color-yellow);
+					position: absolute;
+					font-size: 1.5rem;
+					font-weight: 700;
+					line-height: 1.2;
+					transform: translateX(calc(-150% - 0.5rem)) translateY(45%);
+				}
+			}
+
+			.jurisdiction__reporterList {
+				margin-block-start: var(--spacing-100);
+			}
+
+			.jurisdiction__link {
+				font-weight: 600;
+			}
+		`,
+	];
+
 	connectedCallback() {
 		super.connectedCallback();
 		fetchJurisdictionsData((data) => (this.jurisdictionsData = data));
@@ -18,24 +107,37 @@ export default class CapJurisdictions extends LitElement {
 
 	render() {
 		return html`
-			${Object.keys(this.jurisdictionsData)
-				.sort()
-				.map(
-					(jurisdiction) =>
-						html`<article>
-							<h2>${jurisdiction}</h2>
-							<ul>
-								${this.jurisdictionsData[jurisdiction].map(
-									(reporter) => html`<li>
-										<a href="/caselaw/?reporter=${reporter.slug}"
-											>${reporter.short_name}</a
-										>: ${reporter.full_name}
-										(${reporter.start_year}-${reporter.end_year})
-									</li>`
-								)}
-							</ul>
-						</article>`
-				)}
+			<cap-caselaw-layout>
+				<header class="jurisdictions__header">
+					<cap-page-header heading="Read Caselaw" theme="black" icon="none">
+						<p class="jurisdicrions__description">
+							Browse all volumes of the Caselaw Access Project below.
+						</p>
+					</cap-page-header>
+				</header>
+				<div class="jurisdictions__main">
+					${Object.keys(this.jurisdictionsData)
+						.sort()
+						.map(
+							(jurisdiction) =>
+								html`<article class="jurisdiction">
+									<h2 class="jurisdiction__heading">${jurisdiction}</h2>
+									<ul class="jurisdiction__reporterList">
+										${this.jurisdictionsData[jurisdiction].map(
+											(reporter) => html`<li>
+												<a
+													class="jurisdiction__link"
+													href="/caselaw/?reporter=${reporter.slug}"
+													>${reporter.short_name}</a
+												>: ${reporter.full_name}
+												(${reporter.start_year}-${reporter.end_year})
+											</li>`
+										)}
+									</ul>
+								</article>`
+						)}
+				</div>
+			</cap-caselaw-layout>
 		`;
 	}
 }

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -109,7 +109,7 @@ export default class CapJurisdictions extends LitElement {
 		return html`
 			<cap-caselaw-layout>
 				<header class="jurisdictions__header">
-					<cap-page-header heading="Read Caselaw" theme="black" icon="none">
+					<cap-page-header heading="Read Caselaw" theme="light" icon="none">
 						<p class="jurisdictions__description">
 							Browse all volumes of the Caselaw Access Project below.
 						</p>

--- a/src/components/cap-page-header.js
+++ b/src/components/cap-page-header.js
@@ -27,7 +27,7 @@ export class CapPageHeader extends LitElement {
 					padding-inline: calc(var(--spacing-350) * 2);
 				}
 			}
-			.pageHeader--black {
+			.pageHeader--light {
 				color: var(--color-gray-500);
 			}
 
@@ -68,7 +68,7 @@ export class CapPageHeader extends LitElement {
 
 	constructor() {
 		super();
-		this.theme = "black";
+		this.theme = "light";
 		this.icon = "largeWedge";
 	}
 	render() {

--- a/src/components/cap-page-header.js
+++ b/src/components/cap-page-header.js
@@ -27,7 +27,7 @@ export class CapPageHeader extends LitElement {
 					padding-inline: calc(var(--spacing-350) * 2);
 				}
 			}
-			.pageHeader--darkGray {
+			.pageHeader--black {
 				color: var(--color-gray-500);
 			}
 
@@ -43,7 +43,7 @@ export class CapPageHeader extends LitElement {
 
 	constructor() {
 		super();
-		this.theme = "light";
+		this.theme = "white";
 		this.icon = "largeWedge";
 	}
 	render() {
@@ -54,6 +54,7 @@ export class CapPageHeader extends LitElement {
 					headingLevel="h1"
 					size="large"
 					icon=${this.icon}
+					theme=${this.theme}
 				></cap-decorated-header>
 				<slot></slot>
 			</div>

--- a/src/components/cap-page-header.js
+++ b/src/components/cap-page-header.js
@@ -31,6 +31,18 @@ export class CapPageHeader extends LitElement {
 				color: var(--color-gray-500);
 			}
 
+			.pageHeader__heading {
+				font-size: var(--font-size-300);
+
+				@media (min-width: 65rem) {
+					font-size: var(--font-size-325);
+				}
+
+				font-weight: 600;
+				font-family: var(--font-sans-titling);
+				line-height: 1.125;
+			}
+
 			::slotted(p) {
 				padding-top: var(--spacing-200);
 
@@ -41,21 +53,28 @@ export class CapPageHeader extends LitElement {
 		`,
 	];
 
+	getHeader() {
+		if (this.icon === "none") {
+			return html`<h1 class="pageHeader__heading">${this.heading}</h1>`;
+		}
+
+		return html`<cap-decorated-header
+			heading=${this.heading}
+			headingLevel="h1"
+			size="large"
+			icon=${this.icon}
+		></cap-decorated-header>`;
+	}
+
 	constructor() {
 		super();
-		this.theme = "white";
+		this.theme = "black";
 		this.icon = "largeWedge";
 	}
 	render() {
 		return html`
 			<div class="pageHeader pageHeader--${this.theme} ">
-				<cap-decorated-header
-					heading=${this.heading}
-					headingLevel="h1"
-					size="large"
-					icon=${this.icon}
-					theme=${this.theme}
-				></cap-decorated-header>
+				${this.getHeader()}
 				<slot></slot>
 			</div>
 		`;


### PR DESCRIPTION
## What this does 
This adds the static page content and the scoped css styles we need for the caselaw by jurisdictions landing page. 

## Summary
- Adds page title and description
- Adds `cap-caselaw-layout` component to apply shared layout to all interior caselaw pages
- Adds scoped css styles to `cap-jurisdictions.js`
- Refactors `cap-page-header` to support plain headings as well as decorated headings
- Renames  the `darkGrey` theme used by `cap-page-header` to `light`, to reflect that the page component itself is light, and the light theme displays text in dark grey

## Screenshot
![Screenshot 2024-01-23 at 2 39 51 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/99270407-85e0-4a5e-93c7-e75c036b4dca)

## How to test
- Check out the branch: `git checkout -b tinykite-tinykite-jurisdiction-page-styles main`
- Pull the most recent changes `git pull https://github.com/tinykite/capstone-static.git tinykite-jurisdiction-page-styles`
- In Vscode, the Live Server plugin can be used to launch the website at `http://127.0.0.1:5501/caselaw/`