### PR TITLE
Adds anchor links for jurisdictions & handleHashChange()

### DIFF
--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -103,6 +103,34 @@ export default class CapJurisdictions extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		fetchJurisdictionsData((data) => (this.jurisdictionsData = data));
+		window.addEventListener("hashchange", this.handleHashChange.bind(this));
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener("hashchange", this.handleHashChange.bind(this));
+	}
+
+	/*
+	 In order to preserve encapsulation in the shadow DOM, we need to recreate
+	 the ability to navigate to the anchor tags for each jurisidiction.
+	 Potentially we could have rendered to the window's DOM, but that will be 
+	 potentially problematic when we have to render case HTML, so I started 
+	 using this pattern here.
+	*/
+	handleHashChange() {
+		const hash = window.location.hash.substring(1); // remove the '#'
+		const element = this.shadowRoot.getElementById(hash);
+		if (element) {
+			element.scrollIntoView();
+		}
+	}
+
+	slugify(str) {
+		return str
+			.toLowerCase()
+			.replace(/ /g, "-")
+			.replace(/[^\w-]+/g, "");
 	}
 
 	render() {
@@ -120,7 +148,10 @@ export default class CapJurisdictions extends LitElement {
 						.sort()
 						.map(
 							(jurisdiction) =>
-								html`<article class="jurisdiction">
+								html`<article
+									class="jurisdiction"
+									id="${this.slugify(jurisdiction)}"
+								>
 									<h2 class="jurisdiction__heading">${jurisdiction}</h2>
 									<ul class="jurisdiction__reporterList">
 										${this.jurisdictionsData[jurisdiction].map(


### PR DESCRIPTION
This is an implementation of anchor link targets for jurisdictions.

Since the elements with targeted IDs live in the shadow DOMs of <CapJurisdictions> and <CapContentRouter>, they aren't natively visible in the main window DOM. We need an alternative mechanism to target them.

Ordinarily, we could just turn off the shadow DOM for this component, but that won't work later when we render the case HTML in a shadow DOM and scope the styles to it. I assume this will be necessary to avoid interactions between the `harvard-lil/capstone` sourced, scss-compiled CSS for the case HTML and the rest of the site's styles. We may find out that this is not actually an issue and turn off the shadow DOM for components that require anchor link targets.

This implementation listens for the hashchange event and scrolls the `<article>` for the given jurisdiction into view with `scrollIntoView()`. This is a little wonky if the user subsequently scrolls the view and then reclicks the same link to rescroll the view, because `hashchange` won't fire. Interested in opinions about how/if to deal with that.