### PR TITLE
Add polished styles to the gallery page

### DIFF
--- a/src/components/cap-decorated-header.js
+++ b/src/components/cap-decorated-header.js
@@ -30,11 +30,15 @@ export class CapDecoratedHeader extends LitElement {
 			}
 
 			.heading--medium {
-				font-size: var(--font-size-250);
+				font-size: var(--font-size-150);
+
+				@media (min-width: 35rem) {
+					font-size: var(--font-size-250);
+				}
 			}
 
 			.heading--large {
-				font-size: var(--font-size-300);
+				font-size: var(--font-size-275);
 
 				@media (min-width: 65rem) {
 					font-size: var(--font-size-325);

--- a/src/components/cap-gallery-item.js
+++ b/src/components/cap-gallery-item.js
@@ -24,7 +24,11 @@ export class CapGalleryItem extends LitElement {
 
 			.galleryItem {
 				display: flex;
-				margin-block-start: var(--spacing-400);
+				margin-block-start: var(--spacing-200);
+
+				@media (min-width: 35rem) {
+					margin-block-start: var(--spacing-400);
+				}
 			}
 
 			.galleryItem__image {
@@ -70,7 +74,11 @@ export class CapGalleryItem extends LitElement {
 			}
 
 			.galleryItem__content > * + * {
-				margin-block-start: var(--spacing-200);
+				margin-block-start: var(--spacing-100);
+
+				@media (min-width: 35rem) {
+					margin-block-start: var(--spacing-200);
+				}
 			}
 		`,
 	];

--- a/src/components/cap-gallery-item.js
+++ b/src/components/cap-gallery-item.js
@@ -1,6 +1,7 @@
 import { LitElement, css, html, nothing } from "../lib/lit.js";
 import { baseStyles } from "../lib/wc-base.js";
 import "./cap-arrowRight.js";
+import { githubPath } from "./cap-icons.js";
 
 export class CapGalleryItem extends LitElement {
 	static properties = {
@@ -14,8 +15,16 @@ export class CapGalleryItem extends LitElement {
 	static styles = [
 		baseStyles,
 		css`
+			svg {
+				fill: var(--color-gray-500);
+			}
+			svg:hover {
+				fill: var(--color-yellow);
+			}
+
 			.galleryItem {
 				display: flex;
+				margin-block-start: var(--spacing-400);
 			}
 
 			.galleryItem__image {
@@ -46,8 +55,12 @@ export class CapGalleryItem extends LitElement {
 				}
 			}
 
+			.galleryItem__iconLinkGroup {
+				display: flex;
+			}
+
 			.galleryItem__iconLink {
-				display: block;
+				margin-inline-end: 0.5rem;
 			}
 
 			.galleryItem__content {
@@ -65,26 +78,31 @@ export class CapGalleryItem extends LitElement {
 	constructor() {
 		super();
 		this.image = "/images/gallery-defaultImage.jpg";
-	};
+	}
 
 	getPageLink() {
 		if (this.pageUrl) {
-			return html `<a class="galleryItem__iconLink" href=${this.pageUrl}>
+			return html`<a class="galleryItem__iconLink" href=${this.pageUrl}>
 				<cap-arrow-right></cap-arrow-right>
-				<span class="u-visuallyHidden"
-					>Learn More About ${this.title}</span
-				></a
+				<span class="u-visuallyHidden">Learn More About ${this.title}</span></a
 			>`;
 		} else {
 			return nothing;
 		}
-	};
+	}
 
 	getRepoLink() {
-		// TODO: this wants to be a Github icon
 		if (this.repoUrl) {
-			return html `<a class="galleryItem__iconLink" href=${this.repoUrl}>
-				<cap-arrow-right></cap-arrow-right>
+			return html`<a class="galleryItem__iconLink" href=${this.repoUrl}>
+				<svg
+					width="28"
+					height="28"
+					viewBox="0 0 32 32"
+					fill="currentColor"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					${githubPath}
+				</svg>
 				<span class="u-visuallyHidden"
 					>Source code on Github for ${this.title}</span
 				></a
@@ -92,7 +110,7 @@ export class CapGalleryItem extends LitElement {
 		} else {
 			return nothing;
 		}
-	};
+	}
 
 	render() {
 		return html`
@@ -105,15 +123,20 @@ export class CapGalleryItem extends LitElement {
 				/>
 				<div class="galleryItem__content u-w-maxContent">
 					<h3 class="galleryItem__title">
-						<a class="galleryItem__textLink" href=${this.pageUrl ? this.pageUrl : this.repoUrl}>${this.title}</a>
+						<a
+							class="galleryItem__textLink"
+							href=${this.pageUrl ? this.pageUrl : this.repoUrl}
+							>${this.title}</a
+						>
 					</h3>
 					<p class="galleryItem__description">${this.description}</p>
-					${this.getPageLink()}
-					${this.getRepoLink()}
+					<div class="galleryItem__iconLinkGroup">
+						${this.getPageLink()} ${this.getRepoLink()}
+					</div>
 				</div>
 			</article>
 		`;
-	};
+	}
 }
 
 customElements.define("cap-gallery-item", CapGalleryItem);

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -32,8 +32,16 @@
 	}
 }
 
+.c-article + .c-article {
+	padding-block-start: 0;
+}
+
 .c-article * + * {
-	margin-block-start: var(--spacing-200);
+	margin-block-start: var(--spacing-100);
+
+	@media (min-width: 35rem) {
+		margin-block-start: var(--spacing-200);
+	}
 }
 
 .c-article h2 + * {

--- a/src/templates/cap-about-page.js
+++ b/src/templates/cap-about-page.js
@@ -28,7 +28,7 @@ export class CapAboutPage extends LitElement {
 						</p>
 					</cap-page-header>
 				</header>
-				<aside class="u-w-fit u-sm-hidden">
+				<aside class="u-sm-hidden">
 					<cap-anchor-list .data=${anchorLinks}></cap-anchor-list>
 				</aside>
 				<article class="c-article u-bg-beige">

--- a/src/templates/cap-gallery-page.js
+++ b/src/templates/cap-gallery-page.js
@@ -7,9 +7,7 @@ import "../components/cap-media-list.js";
 import "../components/cap-contributor-list.js";
 import "../components/cap-gallery-item.js";
 
-import { anchorLinks } from "../data/aboutSidebarLinks.js";
 import { gallerySections, galleryItems } from "../data/gallery.js";
-
 
 export class CapGalleryPage extends LitElement {
 	// Turn Shadow DOM off
@@ -24,21 +22,23 @@ export class CapGalleryPage extends LitElement {
 		});
 	}
 
-	getSectionLinks(){
+	getSectionLinks() {
 		return this.getSections().map((section) => {
 			return {
-				"title": section.title,
-				"url": `#${section.titleSlug}`
-			}
+				title: section.title,
+				url: `#${section.titleSlug}`,
+			};
 		});
 	}
 
-	getItemsForSection(section){
-		return galleryItems.filter((item) => {
-			return item.section == section.pk;
-		}).sort((a, b) => {
-			return a.order - b.order;
-		});
+	getItemsForSection(section) {
+		return galleryItems
+			.filter((item) => {
+				return item.section == section.pk;
+			})
+			.sort((a, b) => {
+				return a.order - b.order;
+			});
 	}
 
 	render() {
@@ -58,7 +58,9 @@ export class CapGalleryPage extends LitElement {
 				${this.getSections().map((section) => {
 					return html`
 						<article class="c-article u-bg-beige">
-							<h2 id="${section.titleSlug}">${section.title}</h2>
+							<h2 class="c-decoratedHeader" id="${section.titleSlug}">
+								${section.title}
+							</h2>
 							${this.getItemsForSection(section).map((item) => {
 								return html`
 									<cap-gallery-item

--- a/src/templates/cap-gallery-page.js
+++ b/src/templates/cap-gallery-page.js
@@ -52,7 +52,7 @@ export class CapGalleryPage extends LitElement {
 						</p>
 					</cap-page-header>
 				</header>
-				<aside class="u-w-fit u-sm-hidden">
+				<aside class="u-sm-hidden">
 					<cap-anchor-list .data=${this.getSectionLinks()}></cap-anchor-list>
 				</aside>
 				${this.getSections().map((section) => {


### PR DESCRIPTION
## What this does
Gives a little TLC to the gallery page so that it looks consistent, and as polished, as the about page. 

## Summary 
- Fixes a visual bug where the background color of a hovered sidebar item didn't span the full width of the column 
- Adds vertical spacing around individual gallery items
- Swaps in a Github icon for gallery item links that point to Github
- Styles the section headings for each group of gallery item links with the `decorated-header` utility class
- Adjusts the decorated header's medium heading size for mobile viewports
- Adjust the gallery item margins for mobile viewports
- Fixes an issue where there was doubled vertical padding inbetween article elements


## Screenshots

Smallest mobile viewport 
![Screenshot 2024-01-24 at 2 26 06 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/43c5feea-6cc2-40c8-a3db-5f7dd374c761)

Desktop viewport
![Screenshot 2024-01-24 at 2 09 33 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/39cb499a-920e-4b4d-be4c-c0e4338d87d4)


## How to Test
- Check out the branch: git checkout -b tinykite-polish-gallery-page
- Pull the most recent changes git pull https://github.com/tinykite/capstone-static.git tinykite-polish-gallery-page
- In Vscode, the Live Server plugin can be used to launch the website at http://127.0.0.1:5501/gallery