### PR TITLE
Updated copyright year.

### DIFF
--- a/src/components/cap-footer.js
+++ b/src/components/cap-footer.js
@@ -128,7 +128,7 @@ export class CapFooter extends LitElement {
 				<p class="footer__copyrightNotice">
 					Site text is licensed <a class="footer__textLink footer__textLink--emphasis" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0<a>. <a class="footer__textLink footer__textLink--emphasis" href="https://github.com/harvard-lil/capstone">Source code</a> is MIT licensed.
 					Harvard asserts no copyright in caselaw retrieved from this site.
-					©2023 The President and Fellows of Harvard University.
+					©2024 The President and Fellows of Harvard University.
 				</p>
 			</footer>
 		`;


### PR DESCRIPTION
One of your basic one-character PRs. 

Sets the copyright year in the footer to 2024.