### PR TITLE
Add preliminary styling for case HTML

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -368,7 +368,6 @@ export default class CapCase extends LitElement {
 		window.requestAnimationFrame(doNothing);
 		window.requestAnimationFrame(rewriteLinks);
 		return html`
-			<link href="/css/case.css" rel="stylesheet" />
 			<div class="case-container">
 				<div class="case-header">
 					<h1>Case's Full Citation</h1>

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css, unsafeHTML } from "../lib/lit.js";
+import { LitElement, html, css, unsafeHTML, nothing } from "../lib/lit.js";
 
 import { fetchCaselawBody, fetchCaseMetadata } from "../lib/data.js";
 
@@ -10,6 +10,307 @@ export default class CapCase extends LitElement {
 		volume: { type: String },
 		case: { type: String },
 	};
+
+	static styles = [
+		css`
+			/**/
+			/* Styles for HTML under our control */
+			/**/
+
+			/* .case-container */
+
+			.case-container {
+				flex: 0 0 83.33333%;
+				max-width: 83.33333%;
+				margin: auto;
+
+				padding-top: 0;
+				padding-bottom: 100px;
+
+				/*	styles inherited from "body" in capstone */
+
+				letter-spacing: 0.01em;
+				font-size: 20px;
+				font-weight: normal;
+				line-height: 29px;
+				color: var(--color-gray-500);
+				-moz-osx-font-smoothing: grayscale;
+				-webkit-font-smoothing: antialiased;
+				-webkit-hyphens: auto;
+				-moz-hyphens: auto;
+				-ms-hyphens: auto;
+				hyphens: auto;
+			}
+
+			/* .case-header */
+
+			.case-header {
+				font-size: 0.9em;
+				font-family: "Libre Baskerville", "Baskerville", serif;
+				text-align: center;
+				padding: 2em 2em 0;
+			}
+
+			@media (min-width: 992px) {
+				.case-header {
+					padding: 0;
+				}
+
+				.case-header::after {
+					content: '*';
+					color: var(--color-gray-000);
+				}
+			}
+
+			.case-header > h1 {
+				font-family: "Libre Baskerville", "Baskerville", serif;
+				font-weight: 700;
+				font-size: 1.3em;
+				line-height: 1.4em;
+				padding: 0;
+				margin: 0;
+			}
+
+			.case-header .decision-date, .case-header .court-name {
+				line-height: 1.4em;
+			}
+
+			.case-header .citations {
+				line-height: 2em;
+			}
+
+			/* .metadata */
+
+			.metadata {
+				flex: 0 0 83.33333%;
+				max-width: 83.33333%;
+				margin: auto;
+			}
+
+			.metadata .case-name {
+				flex: 0 0 66.66667%;
+				max-width: 66.66667%;
+				margin-left: 16.66667%;
+				font-family: var(--font-serif);
+				text-align: center
+			}
+
+			.metadata .case-name .case-name-v {
+				display: block;
+				margin: .5em;
+				font-style: italic;
+			}
+
+			/**/
+			/* Styles that apply to the injected HTML */
+			/**/
+
+			/* .casebody */
+
+			.casebody {
+				padding-top: 1em;
+			}
+
+			.casebody section, .casebody article {
+				flex: 0 0 83.33333%;
+				max-width: 83.33333%;
+				margin: auto;
+				padding-top: 1em;
+			}
+
+			.casebody img {
+				max-width: 100%;
+				height: auto;
+			}
+
+			.casebody section {
+				position: relative;
+			}
+
+			.casebody p {
+				font-family: var(--font-serif);
+				margin-top: 1.25rem;
+				margin-bottom: 0;
+			}
+
+			.casebody p.small-text {
+				font-family: var(--font-serif);
+				font-size: 14px;
+				font-weight: 600;
+			}
+
+			.casebody blockquote {
+				font-family: var(--font-serif);
+				margin-left: 0;
+				padding: .5rem 1rem .5rem 1rem;
+				border-left: 0.5rem solid var(--color-gray-000);
+				color: var(--color-blue-500);
+				font-size: 0.875rem;
+				line-height: 1.5;
+			}
+
+			.head-matter > *, .opinion > * {
+				position: relative;
+			}
+
+			section.head-matter {
+				padding-bottom: 0;
+				font-size: 1rem;
+				line-height: 1.5;
+			}
+
+			section.head-matter p.summary, section.head-matter p.history, section.head-matter p.headnotes, section.head-matter p.disposition, section.head-matter p.syllabus, section.head-matter p.attorneys, section.head-matter aside.summary, section.head-matter aside.history, section.head-matter aside.headnotes, section.head-matter aside.disposition, section.head-matter aside.syllabus, section.head-matter aside.attorneys {
+				margin-bottom: 0;
+				margin-top: 0;
+				background-color: var(--color-gray-100);
+				padding: 0rem 2rem 1rem 2rem;
+			}
+
+			section.head-matter :not(.headnotes) + .headnotes:before, section.head-matter :not(.summary) + .summary:before, section.head-matter :not(.history) + .history:before,
+			section.head-matter :not(.syllabus) + .syllabus:before, section.head-matter :not(.disposition) + .disposition:before, section.head-matter :not(.attorneys) + .attorneys:before {
+				padding-left: 0;
+				font-family: var(--font-sans-titling);
+				font-weight: bold;
+				color: var(--color-gray-000);
+				word-break: break-all;
+				text-align: left;
+				font-size: 1rem;
+				text-transform: uppercase;
+				position: absolute;
+				top: 1rem;
+				content: attr(class);
+			}
+
+			section.head-matter :not(.footnote) + .footnote:before {
+				padding-left: 0;
+				font-family: var(--font-sans-titling);
+				font-weight: bold;
+				color: var(--color-gray-000);
+				word-break: break-all;
+				text-align: left;
+				font-size: 1rem;
+				text-transform: uppercase;
+				position: absolute;
+				top: 1rem;
+				content: "Head Matter Footnotes";
+			}
+
+			section.head-matter :not(.headnotes) + .headnotes, section.head-matter :not(.summary) + .summary, section.head-matter :not(.history) + .history,
+			section.head-matter :not(.syllabus) + .syllabus, section.head-matter :not(.disposition) + .disposition, section.head-matter :not(.attorneys) + .attorneys,
+			section.head-matter :not(.footnote) + .footnote {
+				margin-top: 1rem;
+				padding-bottom: 1rem;
+				padding-top: 3rem;
+			}
+
+			section.head-matter .page-label:before {
+				display: none;
+			}
+
+			section.head-matter .footnote {
+				margin-bottom: 0;
+				margin-top: 0;
+				background-color: var(--color-gray-100);
+				padding: 0rem 2rem 1rem 2rem;
+			}
+
+			section.head-matter .footnote > p, section.head-matter footnote > blockquote {
+				padding-bottom: .5em;
+				margin-bottom: 0;
+			}
+
+			/* hidden, because this information is otherwise displayed on the page */
+			.parties, .docketnumber, .decisiondate {
+				display: none;
+			}
+
+			.attorneys, .judges {
+				text-align: left;
+				font-size: 1.25rem;
+			}
+
+			.author {
+				font-size: 1.25rem;
+				color: var(--color-purple-200);
+			}
+
+			.author:before {
+				content: "Author: ";
+				color: var(--color-gray-500);
+			}
+
+			.opinion {
+				padding-top: 2em;
+			}
+
+			.opinion:before {
+				content: "Opinion";
+				font-weight: bold;
+				font-family: "Libre Baskerville", "Baskerville", serif;
+			}
+
+			.opinion > p {
+				margin-bottom: 15px;
+			}
+
+			.footnotemark {
+				border-bottom: 0;
+				margin-bottom: 5px;
+				color: var(--color-purple-200);
+				vertical-align: super;
+				font-size: .75rem;
+				font-weight: bold; }
+
+			.footnote {
+				font-size: 0.875rem;
+				line-height: 1.5;
+				padding: 0rem 2rem 1rem 2rem;
+				line-height: 1.5;
+				position: relative;
+			}
+
+			.footnote > p, .footnote > blockquote {
+				margin-bottom: .5em;
+				margin-top: 0;
+			}
+
+			.footnote > a {
+				position: absolute;
+				left: .5rem;
+				border-bottom: 0;
+				font-weight: 700;
+				color: var(--color-purple-200);
+				font-family: var(--font-serif);
+				font-size: .75rem;
+			}
+
+			.footnote:target {
+				background-color: var(--color-pink-000);
+			}
+
+			.footnote .page-label:before {
+				display: none;
+				text-align: left;
+			}
+
+			.page-label {
+				color: var(--color-gray-000);
+				font-size: .8em;
+				padding: .4em;
+				font-style: italic;
+			}
+
+			.page-label:before {
+				display: inline-block;
+				content: attr(data-label);
+				position: absolute;
+				left: 0;
+				transform: translateX(-100%);
+				padding-right: 1em;
+				font-size: 1.2rem;
+			}
+		`
+	]
 
 	constructor() {
 		super();
@@ -34,6 +335,17 @@ export default class CapCase extends LitElement {
 		);
 	}
 
+	getDocketNumber() {
+		if (true){
+			return html`
+				<span>&middot;</span>
+				<span class="docket-number">Docket Number</span>
+			`;
+		} else {
+			return nothing;
+		}
+	}
+
 	render() {
 		/*
 		This render method uses requestAnimationFrame to alter the links in
@@ -49,12 +361,38 @@ export default class CapCase extends LitElement {
 			this.shadowRoot.querySelectorAll("a").forEach((a) => {
 				const oldLink = a.getAttribute("href");
 				//todo we need to fix this when ENG-523 happens
+				// (and we should make sure we don't break footnotes when we do)
 				a.href = oldLink + "#todo";
 			});
 		};
 		window.requestAnimationFrame(doNothing);
 		window.requestAnimationFrame(rewriteLinks);
-		return html`${unsafeHTML(this.caseBody)}`;
+		return html`
+			<link href="/css/case.css" rel="stylesheet" />
+			<div class="case-container">
+				<div class="case-header">
+					<h1>Case's Full Citation</h1>
+					<div>
+						<span class="decision-date">Formatted Decision Date</span>
+						<span>&middot;</span>
+						<span class="court-name">Court Name</span>
+						${this.getDocketNumber()}
+					</div>
+					 <div class="citations">
+						Citation, Citation, Citation
+					</div>
+				</div>
+				<div class="metadata">
+					<div class="case-name">
+						SOMEBODY
+						<span class="case-name-v">v.</span>
+						SOMEBODY ELSE
+					</div>
+				</div>
+				<!--section.casebody -->
+				${unsafeHTML(this.caseBody)}
+			</div>
+		`;
 	}
 }
 

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -57,7 +57,7 @@ export default class CapCase extends LitElement {
 				}
 
 				.case-header::after {
-					content: '*';
+					content: "*";
 					color: var(--color-gray-000);
 				}
 			}
@@ -71,7 +71,8 @@ export default class CapCase extends LitElement {
 				margin: 0;
 			}
 
-			.case-header .decision-date, .case-header .court-name {
+			.case-header .decision-date,
+			.case-header .court-name {
 				line-height: 1.4em;
 			}
 
@@ -92,12 +93,12 @@ export default class CapCase extends LitElement {
 				max-width: 66.66667%;
 				margin-left: 16.66667%;
 				font-family: var(--font-serif);
-				text-align: center
+				text-align: center;
 			}
 
 			.metadata .case-name .case-name-v {
 				display: block;
-				margin: .5em;
+				margin: 0.5em;
 				font-style: italic;
 			}
 
@@ -111,7 +112,8 @@ export default class CapCase extends LitElement {
 				padding-top: 1em;
 			}
 
-			.casebody section, .casebody article {
+			.casebody section,
+			.casebody article {
 				flex: 0 0 83.33333%;
 				max-width: 83.33333%;
 				margin: auto;
@@ -142,14 +144,15 @@ export default class CapCase extends LitElement {
 			.casebody blockquote {
 				font-family: var(--font-serif);
 				margin-left: 0;
-				padding: .5rem 1rem .5rem 1rem;
+				padding: 0.5rem 1rem 0.5rem 1rem;
 				border-left: 0.5rem solid var(--color-gray-000);
 				color: var(--color-blue-500);
 				font-size: 0.875rem;
 				line-height: 1.5;
 			}
 
-			.head-matter > *, .opinion > * {
+			.head-matter > *,
+			.opinion > * {
 				position: relative;
 			}
 
@@ -159,15 +162,30 @@ export default class CapCase extends LitElement {
 				line-height: 1.5;
 			}
 
-			section.head-matter p.summary, section.head-matter p.history, section.head-matter p.headnotes, section.head-matter p.disposition, section.head-matter p.syllabus, section.head-matter p.attorneys, section.head-matter aside.summary, section.head-matter aside.history, section.head-matter aside.headnotes, section.head-matter aside.disposition, section.head-matter aside.syllabus, section.head-matter aside.attorneys {
+			section.head-matter p.summary,
+			section.head-matter p.history,
+			section.head-matter p.headnotes,
+			section.head-matter p.disposition,
+			section.head-matter p.syllabus,
+			section.head-matter p.attorneys,
+			section.head-matter aside.summary,
+			section.head-matter aside.history,
+			section.head-matter aside.headnotes,
+			section.head-matter aside.disposition,
+			section.head-matter aside.syllabus,
+			section.head-matter aside.attorneys {
 				margin-bottom: 0;
 				margin-top: 0;
 				background-color: var(--color-gray-100);
 				padding: 0rem 2rem 1rem 2rem;
 			}
 
-			section.head-matter :not(.headnotes) + .headnotes:before, section.head-matter :not(.summary) + .summary:before, section.head-matter :not(.history) + .history:before,
-			section.head-matter :not(.syllabus) + .syllabus:before, section.head-matter :not(.disposition) + .disposition:before, section.head-matter :not(.attorneys) + .attorneys:before {
+			section.head-matter :not(.headnotes) + .headnotes:before,
+			section.head-matter :not(.summary) + .summary:before,
+			section.head-matter :not(.history) + .history:before,
+			section.head-matter :not(.syllabus) + .syllabus:before,
+			section.head-matter :not(.disposition) + .disposition:before,
+			section.head-matter :not(.attorneys) + .attorneys:before {
 				padding-left: 0;
 				font-family: var(--font-sans-titling);
 				font-weight: bold;
@@ -195,8 +213,12 @@ export default class CapCase extends LitElement {
 				content: "Head Matter Footnotes";
 			}
 
-			section.head-matter :not(.headnotes) + .headnotes, section.head-matter :not(.summary) + .summary, section.head-matter :not(.history) + .history,
-			section.head-matter :not(.syllabus) + .syllabus, section.head-matter :not(.disposition) + .disposition, section.head-matter :not(.attorneys) + .attorneys,
+			section.head-matter :not(.headnotes) + .headnotes,
+			section.head-matter :not(.summary) + .summary,
+			section.head-matter :not(.history) + .history,
+			section.head-matter :not(.syllabus) + .syllabus,
+			section.head-matter :not(.disposition) + .disposition,
+			section.head-matter :not(.attorneys) + .attorneys,
 			section.head-matter :not(.footnote) + .footnote {
 				margin-top: 1rem;
 				padding-bottom: 1rem;
@@ -214,17 +236,21 @@ export default class CapCase extends LitElement {
 				padding: 0rem 2rem 1rem 2rem;
 			}
 
-			section.head-matter .footnote > p, section.head-matter footnote > blockquote {
-				padding-bottom: .5em;
+			section.head-matter .footnote > p,
+			section.head-matter footnote > blockquote {
+				padding-bottom: 0.5em;
 				margin-bottom: 0;
 			}
 
 			/* hidden, because this information is otherwise displayed on the page */
-			.parties, .docketnumber, .decisiondate {
+			.parties,
+			.docketnumber,
+			.decisiondate {
 				display: none;
 			}
 
-			.attorneys, .judges {
+			.attorneys,
+			.judges {
 				text-align: left;
 				font-size: 1.25rem;
 			}
@@ -258,8 +284,9 @@ export default class CapCase extends LitElement {
 				margin-bottom: 5px;
 				color: var(--color-purple-200);
 				vertical-align: super;
-				font-size: .75rem;
-				font-weight: bold; }
+				font-size: 0.75rem;
+				font-weight: bold;
+			}
 
 			.footnote {
 				font-size: 0.875rem;
@@ -269,19 +296,20 @@ export default class CapCase extends LitElement {
 				position: relative;
 			}
 
-			.footnote > p, .footnote > blockquote {
-				margin-bottom: .5em;
+			.footnote > p,
+			.footnote > blockquote {
+				margin-bottom: 0.5em;
 				margin-top: 0;
 			}
 
 			.footnote > a {
 				position: absolute;
-				left: .5rem;
+				left: 0.5rem;
 				border-bottom: 0;
 				font-weight: 700;
 				color: var(--color-purple-200);
 				font-family: var(--font-serif);
-				font-size: .75rem;
+				font-size: 0.75rem;
 			}
 
 			.footnote:target {
@@ -295,8 +323,8 @@ export default class CapCase extends LitElement {
 
 			.page-label {
 				color: var(--color-gray-000);
-				font-size: .8em;
-				padding: .4em;
+				font-size: 0.8em;
+				padding: 0.4em;
 				font-style: italic;
 			}
 
@@ -309,8 +337,8 @@ export default class CapCase extends LitElement {
 				padding-right: 1em;
 				font-size: 1.2rem;
 			}
-		`
-	]
+		`,
+	];
 
 	constructor() {
 		super();
@@ -336,7 +364,7 @@ export default class CapCase extends LitElement {
 	}
 
 	getDocketNumber() {
-		if (true){
+		if (true) {
 			return html`
 				<span>&middot;</span>
 				<span class="docket-number">Docket Number</span>
@@ -377,9 +405,7 @@ export default class CapCase extends LitElement {
 						<span class="court-name">Court Name</span>
 						${this.getDocketNumber()}
 					</div>
-					 <div class="citations">
-						Citation, Citation, Citation
-					</div>
+					<div class="citations">Citation, Citation, Citation</div>
 				</div>
 				<div class="metadata">
 					<div class="case-name">

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -46,7 +46,7 @@ export default class CapCase extends LitElement {
 
 			.case-header {
 				font-size: 0.9em;
-				font-family: "Libre Baskerville", "Baskerville", serif;
+				font-family: var(--font-serif-titling);
 				text-align: center;
 				padding: 2em 2em 0;
 			}
@@ -63,7 +63,7 @@ export default class CapCase extends LitElement {
 			}
 
 			.case-header > h1 {
-				font-family: "Libre Baskerville", "Baskerville", serif;
+				font-family: var(--font-serif-titling);
 				font-weight: 700;
 				font-size: 1.3em;
 				line-height: 1.4em;
@@ -246,7 +246,7 @@ export default class CapCase extends LitElement {
 			.opinion:before {
 				content: "Opinion";
 				font-weight: bold;
-				font-family: "Libre Baskerville", "Baskerville", serif;
+				font-family: var(--font-serif-titling);
 			}
 
 			.opinion > p {

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -16,7 +16,7 @@ export default class CapContentRouter extends LitElement {
 				padding-top: 2.5rem;
 				padding-bottom: 3rem;
 			}
-		`
+		`,
 	];
 
 	render() {

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -1,10 +1,24 @@
-import { html, LitElement } from "../lib/lit.js";
+import { html, css, LitElement } from "../lib/lit.js";
+
 import "./cap-volume.js";
 import "./cap-case.js";
 import "./cap-jurisdictions.js";
 import "./cap-reporter.js";
 
 export default class CapContentRouter extends LitElement {
+	static styles = [
+		css`
+			cap-case {
+				display: block;
+				flex: 0 0 58.33333%;
+				max-width: 58.33333%;
+				margin: auto;
+				padding-top: 2.5rem;
+				padding-bottom: 3rem;
+			}
+		`
+	];
+
 	render() {
 		const searchParams = new URLSearchParams(window.location.search);
 		const reporter = searchParams.get("reporter");

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -24,7 +24,7 @@
 	--color-purple-200: #e878ff;
 	--color-purple-300: #4830fd;
 
-	--color-pink-000: #fff1f8;
+	--color-pink-100: #fff1f8;
 
 	--color-gradient: linear-gradient(
 		45deg,

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -2,6 +2,7 @@
 	--color-white: #ffffff;
 	--color-beige: #f7f6f2;
 
+	--color-gray-000: #979797;
 	--color-gray-100: #f7f7f9;
 	--color-gray-200: #ced4da;
 	--color-gray-300: #6c757d;
@@ -22,6 +23,8 @@
 	--color-purple-100: #b3a7fd;
 	--color-purple-200: #e878ff;
 	--color-purple-300: #4830fd;
+
+	--color-pink-000: #fff1f8;
 
 	--color-gradient: linear-gradient(
 		45deg,

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -18,4 +18,5 @@
 	--font-serif: "Source Serif VF", baskerville, georgia, serif;
 	--font-mono: source-code, monospace;
 	--font-sans-titling: titillium, sans-serif;
+	--font-serif-titling: "Libre Baskerville", "Baskerville", serif;
 }


### PR DESCRIPTION
This PR takes a swing at adding some styling for rendered cases.

### Strategy

My strategy... is questionable: I will not take offense in the least if we decide to close this PR instead of merging it, and have me try again using a different approach 🙂.

Here is what I did:

1) I ran `./manage.py collectstatic` in the capstone repo, in order to convert the [case-specific scss](https://github.com/harvard-lil/capstone/blob/00bb5a8104efe258474b4bce6e72c586adcc4279/capstone/static/css/scss/case.scss) to plain css.

2) I extracted _only_ the styles explicitly defined in case.scss. I did _not_ copy any of the styles that came from the imports:
```
@import "base.scss";
@import 'bootstrap/_functions.scss';
@import 'bootstrap/_variables.scss';
@import 'bootstrap/mixins';
@import 'bootstrap/tooltip';

@import "case_sidebar";
```

3) I sifted through and removed styles that don't refer to elements that will exist in this version of the site (no tooltips, no elided/redacted text, no specially-highlighted text (via injected "mark" tags), no error messages, no custom footers, no selection tools ((so far as I know)).

4) I slavishly reproduced the HTML currently used by capstone, including kebab-case class names.

5) I sorted the exported css into two categories: declarations that apply to the HTML defined in cap-case.js (and therefore under our control... which is to say, modifiable), and declarations that apply to the HTML we are injecting straight from the CAP data (which is to say, not easily modifiable). I refactored as little as possible in the process, trying to keep things as close to the original as possible.

6) I swapped in this project's CSS variables for font-family and color where possible, adding a couple of colors where nothing in the existing palette was a near match... with a goofy `000` suffix, because I wasn't sure how to pick a correct number for the existing system 🤣 

7) I loaded a few cases in my browser and looked for things that looked wrong, using the inspector to locate and add "missing" styles (things that were inherited from capstone's "base" classes like .simple-page or base elements like `body` and `div`)... until I couldn't spot any more discrepancies.

Specifically, I used `/caselaw/?reporter=nc&volume=355&case=0354` (https://cite.case.law/nc/355/354/), `/caselaw/?reporter=nc&volume=369&case=0264` (https://cite.case.law/nc/369/264/) and `/caselaw/?reporter=nc&volume=369&case=0126` (https://cite.case.law/nc/369/126/), at Jack's suggestion.

### Problems with that strategy

I am not sure whether case HTML may contain arbitrary HTML elements (`code`? `table`? `ul/ol`?). If yes, then the appearance of those elements is influenced by capstone's base styles (which includes a `normalize` reset and Bootstrap stuff in addition to custom styles)... which is not reproduced here.

@jcushman probably knows whether that is even a possibility we need to consider... though, even if it is possible, we may choose not to worry about it, and just let browser default styles do their thing.

The code added by this PR is also ugly, and non-idiomatic, because of the approach I took 😂. Font sizes, spacing, line-height, margins, padding are applied without making any effort to switch over / fit in to the nice clean system defined by `typography.css`, `spacing.css`, and this project's other utilities.

All of which is to say... this might not be what we want.

### Good things about that strategy

On the other hand... it doesn't look half bad in the browser! I may have missed things... but to my eye, it looks just like the original.

Could be that this is close enough for jazz.... or at least, good enough commit, and then somebody can come in and do a second pass, refactoring as they see fit.

### Reviewing

It is probably worth pulling this down and trying a few cases at random... I won't suggest any, to increase the chances that you pick something I haven't looked at yet 😂.

I'll include a screenshot of a long case (the longest screenshot Chrome can make) for convenience as well.

But I think basically what we are looking for here is... thoughts on how to make this less bad? And opinions on whether this is indeed close enough for jazz, or if we want to modify the approach instead.

Of course, "LGTM!" is always a good answer 😄 

![localhost_5501_caselaw__reporter=nc volume=369 case=0264](https://github.com/harvard-lil/capstone-static/assets/11020492/1fb3097a-a087-4feb-84c4-3785618f1825)
