### PR TITLE
404 page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "liveServer.settings.port": 5501,
     "liveServer.settings.root": "./src",
+    "liveServer.settings.file": "404.html",
 }

--- a/run.py
+++ b/run.py
@@ -3,12 +3,19 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler, test
 
 
 class CORSRequestHandler (SimpleHTTPRequestHandler):
+
     def end_headers (self):
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', '*')
         self.send_header('Access-Control-Allow-Headers', '*')
         self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
         SimpleHTTPRequestHandler.end_headers(self)
+
+    def send_error(self, code, message=None):
+        if code == 404:
+            with open('404.html') as not_found:
+                self.error_message_format = not_found.read()
+        SimpleHTTPRequestHandler.send_error(self, code, message)
 
 
 if __name__ == '__main__':

--- a/src/404.html
+++ b/src/404.html
@@ -65,7 +65,9 @@
 			<header class="u-bg-gray-500 u-col-span-full">
 				<cap-page-header heading="Hmm... can't find that.">
 					<p class="u-text-white u-text-serif">
-						Maybe the last borrower didn't return that link.<br />
+						Maybe the last borrower didn't return that link.
+					</p>
+					<p class="u-text-white u-text-serif">
 						If you got here through our site or an article we host, please let
 						us know at
 						<a class="u-text-purple-200" href="mailto:info@case.law"

--- a/src/404.html
+++ b/src/404.html
@@ -70,7 +70,7 @@
 					<p class="u-text-white u-text-serif">
 						If you got here through our site or an article we host, please let
 						us know at
-						<a class="u-text-purple-200" href="mailto:info@case.law"
+						<a class="u-link-purple" href="mailto:info@case.law"
 							>info@case.law</a
 						>
 						so we can fix it.

--- a/src/404.html
+++ b/src/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<title>404 Not Found | Caselaw Access Project</title>
@@ -18,15 +18,46 @@
 		<script type="module" src="/components/cap-page-header.js"></script>
 		<script type="module" src="/components/cap-footer.js"></script>
 
-		<link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon.png">
-		<link rel="icon" type="image/png" sizes="192x192"  href="/images/favicon/android-chrome-144x144.png">
-		<link rel="icon" type="image/png" sizes="96x96" href="/images/favicon/favicon.ico">
-		<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
-		<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
-		<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#0075FF">
-		<meta name="msapplication-TileColor" content="#2b5797">
-		<meta name="msapplication-TileImage" content="/images/favicon/mstile-150x150.png">
-		<meta name="theme-color" content="#ffffff">
+		<link
+			rel="apple-touch-icon"
+			sizes="152x152"
+			href="/images/favicon/apple-touch-icon.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="192x192"
+			href="/images/favicon/android-chrome-144x144.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="96x96"
+			href="/images/favicon/favicon.ico"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="32x32"
+			href="/images/favicon/favicon-32x32.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="16x16"
+			href="/images/favicon/favicon-16x16.png"
+		/>
+		<link
+			rel="mask-icon"
+			href="/images/favicon/safari-pinned-tab.svg"
+			color="#0075FF"
+		/>
+		<meta name="msapplication-TileColor" content="#2b5797" />
+		<meta
+			name="msapplication-TileImage"
+			content="/images/favicon/mstile-150x150.png"
+		/>
+		<meta name="theme-color" content="#ffffff" />
 	</head>
 	<body>
 		<cap-nav></cap-nav>
@@ -34,8 +65,13 @@
 			<header class="u-bg-gray-500 u-col-span-full">
 				<cap-page-header heading="Hmm... can't find that.">
 					<p class="u-text-white u-text-serif">
-						Maybe the last borrower didn't return that link.<br>
-						If you got here through our site or an article we host, please let us know at <a class="u-text-purple-200" href="mailto:info@case.law">info@case.law</a> so we can fix it.
+						Maybe the last borrower didn't return that link.<br />
+						If you got here through our site or an article we host, please let
+						us know at
+						<a class="u-text-purple-200" href="mailto:info@case.law"
+							>info@case.law</a
+						>
+						so we can fix it.
 					</p>
 				</cap-page-header>
 			</header>

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>404 Not Found | Caselaw Access Project</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<meta name="author" content="Your name" />
+		<meta name="description" content="Explore American Caselaw" />
+		<meta property="og:title" content="Caselaw Access Project" />
+		<meta property="og:description" content="Explore American Caselaw" />
+		<meta property="og:url" content="https://case.law/" />
+		<meta property="og:type" content="article" />
+		<meta property="og:site_name" content="Caselaw Access Projects" />
+
+		<link href="css/global.css" rel="stylesheet" />
+		<script type="module" src="components/cap-nav.js"></script>
+		<script type="module" src="components/cap-page-header.js"></script>
+		<script type="module" src="components/cap-footer.js"></script>
+
+		<link rel="apple-touch-icon" sizes="152x152" href="images/favicon/apple-touch-icon.png">
+		<link rel="icon" type="image/png" sizes="192x192"  href="images/favicon/android-chrome-144x144.png">
+		<link rel="icon" type="image/png" sizes="96x96" href="images/favicon/favicon.ico">
+		<link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
+		<link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg" color="#0075FF">
+		<meta name="msapplication-TileColor" content="#2b5797">
+		<meta name="msapplication-TileImage" content="images/favicon/mstile-150x150.png">
+		<meta name="theme-color" content="#ffffff">
+	</head>
+	<body>
+		<cap-nav></cap-nav>
+		<main id="main" class="l-interiorPage">
+			<header class="u-bg-gray-500 u-col-span-full">
+				<cap-page-header heading="Hmm... can't find that.">
+					<p class="u-text-white u-text-serif">
+						Maybe the last borrower didn't return that link.<br>
+						If you got here through our site or an article we host, please let us know at <a class="u-text-purple-200" href="mailto:info@case.law">info@case.law</a> so we can fix it.
+					</p>
+				</cap-page-header>
+			</header>
+		</main>
+		<cap-footer></cap-footer>
+	</body>
+</html>

--- a/src/404.html
+++ b/src/404.html
@@ -13,19 +13,19 @@
 		<meta property="og:type" content="article" />
 		<meta property="og:site_name" content="Caselaw Access Projects" />
 
-		<link href="css/global.css" rel="stylesheet" />
-		<script type="module" src="components/cap-nav.js"></script>
-		<script type="module" src="components/cap-page-header.js"></script>
-		<script type="module" src="components/cap-footer.js"></script>
+		<link href="/css/global.css" rel="stylesheet" />
+		<script type="module" src="/components/cap-nav.js"></script>
+		<script type="module" src="/components/cap-page-header.js"></script>
+		<script type="module" src="/components/cap-footer.js"></script>
 
-		<link rel="apple-touch-icon" sizes="152x152" href="images/favicon/apple-touch-icon.png">
-		<link rel="icon" type="image/png" sizes="192x192"  href="images/favicon/android-chrome-144x144.png">
-		<link rel="icon" type="image/png" sizes="96x96" href="images/favicon/favicon.ico">
-		<link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
-		<link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
-		<link rel="mask-icon" href="images/favicon/safari-pinned-tab.svg" color="#0075FF">
+		<link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon.png">
+		<link rel="icon" type="image/png" sizes="192x192"  href="/images/favicon/android-chrome-144x144.png">
+		<link rel="icon" type="image/png" sizes="96x96" href="/images/favicon/favicon.ico">
+		<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+		<link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#0075FF">
 		<meta name="msapplication-TileColor" content="#2b5797">
-		<meta name="msapplication-TileImage" content="images/favicon/mstile-150x150.png">
+		<meta name="msapplication-TileImage" content="/images/favicon/mstile-150x150.png">
 		<meta name="theme-color" content="#ffffff">
 	</head>
 	<body>

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -96,3 +96,14 @@ a:active {
 		text-decoration: underline;
 	}
 }
+
+.u-text-white a:link,
+.u-text-white a:visited,
+.u-text-whit a:hover,
+.u-text-white a:active {
+	color: var(--color-purple-200);
+
+	&:hover {
+		filter: brightness(0.75);
+	}
+}

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -96,14 +96,3 @@ a:active {
 		text-decoration: underline;
 	}
 }
-
-.u-text-white a:link,
-.u-text-white a:visited,
-.u-text-whit a:hover,
-.u-text-white a:active {
-	color: var(--color-purple-200);
-
-	&:hover {
-		filter: brightness(0.75);
-	}
-}

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -42,9 +42,21 @@
 	color: var(--color-purple-200);
 }
 
+.u-link-purple:link,
+.u-link-purple:hover,
+.u-link-purple:visited,
+.u-link-purple:active {
+	color: var(--color-purple-200);
+	&:hover {
+		color: var(--color-purple-200);
+		filter: brightness(0.75);
+	}
+}
+
 .u-margin-block-start-275 {
 	margin-block-start: var(--spacing-275);
 }
+
 .u-sm-hidden {
 	@media (max-width: 60rem) {
 		display: none;


### PR DESCRIPTION
The Github Pages docs suggest that merely [creating `404.html` in `src`](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) will cause it to serve a custom 404 page in lieu of its default.

This PR gives it a try!

It also sets up `run.py` to serve it in place of its built-in 404... and, if I have understood the [VSCode extension docs correctly](https://github.com/ritwickdey/vscode-live-server/blob/428e01caf02bfa7ee75741df0f02fc9d2b5b0999/package.json#L292
), sets up that as well.

404 for case.law looks like this:

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/68e6c23f-8d83-4313-815b-08b04058ca8e)

The page I'm adding looks like this:

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/2537d164-5eea-4878-90b6-13a0fdc2cfa2)

(w/link hover style)

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/e647890b-578e-45e0-9a57-5671c75c57e1)

I added styles for the purple links (which have to be in the base document, because that text is in a slot, and therefore is in the "light DOM", not the shadow DOM. (Or... that is my current understanding of the situation LOL.)

I did not attempt to make the footer sticky (see ENG-564); I can, but would like to discuss technique with Dakota: the way I know is old, and there are probably better ways now LOL!