### PR TITLE
Rek style volume

### DIFF
--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -66,18 +66,16 @@ export default class CapReporter extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-block-end: var(--spacing-75);
 			}
 
 			.reporter__subHeading {
 				font-size: var(--font-size-175);
 				margin-block-start: var(--spacing-0);
-				margin-block-end: var(--spacing-150);
 				font-weight: 500;
 			}
 
 			.reporter__volumeList {
-				margin-block-start: var(--spacing-100);
+				margin-block-start: var(--spacing-150);
 				display: block;
 			}
 

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -66,7 +66,7 @@ export default class CapReporter extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-bottom: .5rem;
+				margin-bottom: 0.5rem;
 			}
 
 			.reporter__subHeading {

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -44,11 +44,11 @@ export default class CapReporter extends LitElement {
 			a:active {
 				text-decoration: none;
 				color: var(--color-blue-400);
+			}
 
-				&:hover {
-					color: var(--color-blue-500);
-					text-decoration: underline;
-				}
+			a:hover {
+				color: var(--color-blue-500);
+				text-decoration: underline;
 			}
 
 			.reporters__main {
@@ -66,13 +66,13 @@ export default class CapReporter extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-bottom: 0.5rem;
+				margin-block-end: var(--spacing-75);
 			}
 
 			.reporter__subHeading {
 				font-size: var(--font-size-175);
-				margin-top: 0;
-				margin-bottom: 1rem;
+				margin-block-start: var(--spacing-0);
+				margin-block-end: var(--spacing-150);
 				font-weight: 500;
 			}
 

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -66,6 +66,7 @@ export default class CapReporter extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
+				margin-bottom: .5rem;
 			}
 
 			.reporter__subHeading {
@@ -78,10 +79,6 @@ export default class CapReporter extends LitElement {
 			.reporter__volumeList {
 				margin-block-start: var(--spacing-100);
 				display: block;
-			}
-
-			.reporter__link {
-				font-weight: 600;
 			}
 
 			.list__title {

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -71,18 +71,16 @@ export default class CapVolume extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-block-end: var(--spacing-75);
 			}
 
 			.volume__subHeading {
 				font-size: var(--font-size-175);
 				margin-block-start: var(--spacing-0);
-				margin-block-end: var(--spacing-150);
 				font-weight: 500;
 			}
 
 			.volume__caseList {
-				margin-block-start: var(--spacing-100);
+				margin-block-start: var(--spacing-150);
 				display: block;
 			}
 		`,

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -49,11 +49,11 @@ export default class CapVolume extends LitElement {
 			a:active {
 				text-decoration: none;
 				color: var(--color-blue-400);
+			}
 
-				&:hover {
-					color: var(--color-blue-500);
-					text-decoration: underline;
-				}
+			a:hover {
+				color: var(--color-blue-500);
+				text-decoration: underline;
 			}
 
 			.volumes__main {
@@ -71,7 +71,14 @@ export default class CapVolume extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-bottom: 0.5rem;
+				margin-block-end: var(--spacing-75);
+			}
+
+			.volume__subHeading {
+				font-size: var(--font-size-175);
+				margin-block-start: var(--spacing-0);
+				margin-block-end: var(--spacing-150);
+				font-weight: 500;
 			}
 
 			.volume__caseList {
@@ -105,7 +112,7 @@ export default class CapVolume extends LitElement {
 						<h1 class="volume__heading">
 							${this.volume} ${this.reporterData.short_name}
 						</h1>
-						<p>
+						<p class="volume__subHeading">
 							${this.reporterData.full_name}
 							(${this.reporterData.start_year}-${this.reporterData.end_year})
 							volume ${this.volume}.

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -66,6 +66,18 @@ export default class CapVolume extends LitElement {
 					grid-column: 1 / -1;
 				}
 			}
+
+			.volume__heading {
+				font-weight: 600;
+				font-size: var(--font-size-250);
+				position: relative;
+				margin-bottom: .5rem;
+			}
+
+			.volume__caseList {
+				margin-block-start: var(--spacing-100);
+				display: block;
+			}
 		`
 	]
 
@@ -90,13 +102,15 @@ export default class CapVolume extends LitElement {
 		return html`
 			<cap-caselaw-layout>
 				<div class="volumes__main">
-					<h1>${this.volume} ${this.reporterData.short_name}</h1>
-					<h2>
-						${this.reporterData.full_name}
-						(${this.reporterData.start_year}-${this.reporterData.end_year}) volume
-						${this.volume}
-					</h2>
-					<ul>
+					<hgroup>
+						<h1 class="volume__heading">${this.volume} ${this.reporterData.short_name}</h1>
+						<p>
+							${this.reporterData.full_name}
+							(${this.reporterData.start_year}-${this.reporterData.end_year}) volume
+							${this.volume}.
+						</p>
+					</hgroup>
+					<ul class="volume__caseList">
 						${this.casesData.map(
 							(c) =>
 								html`<li>

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -4,6 +4,7 @@ import {
 	fetchReporterData,
 	fetchVolumeData,
 } from "../lib/data.js";
+import { baseStyles } from "../lib/wc-base.js";
 
 export default class CapVolume extends LitElement {
 	static properties = {
@@ -20,6 +21,54 @@ export default class CapVolume extends LitElement {
 		this.reporterData = {};
 		this.volumeData = {};
 	}
+
+	static styles = [
+		baseStyles,
+
+		css`
+			p,
+			ul {
+				font-family: var(--font-sans-text);
+
+				@media (min-width: 35rem) {
+					font-size: var(--font-size-175);
+				}
+			}
+
+			ul {
+				padding: 0;
+			}
+
+			li {
+				list-style-type: none;
+			}
+
+			a:link,
+			a:visited,
+			a:hover,
+			a:active {
+				text-decoration: none;
+				color: var(--color-blue-400);
+
+				&:hover {
+					color: var(--color-blue-500);
+					text-decoration: underline;
+				}
+			}
+
+			.volumes__main {
+				grid-column: 1 / -1;
+				padding-inline: var(--spacing-500);
+				padding-block-start: var(--spacing-300);
+				padding-block-end: var(--spacing-550);
+
+				@media (min-width: 60rem) {
+					grid-column: 1 / -1;
+				}
+			}
+		`
+	]
+
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -39,27 +88,31 @@ export default class CapVolume extends LitElement {
 	render() {
 		//todo this will need to be updated to deal with multiple cases on the same page
 		return html`
-			<h1>${this.volume} ${this.reporterData.short_name}</h1>
-			<h2>
-				${this.reporterData.full_name}
-				(${this.reporterData.start_year}-${this.reporterData.end_year}) volume
-				${this.volume}
-			</h2>
-			<ul>
-				${this.casesData.map(
-					(c) =>
-						html`<li>
-							<a
-								href="/caselaw/?reporter=${this.reporter}&volume=${this
-									.volume}&case=${String(c.first_page).padStart(4, "0")}"
-							>
-								${c.name_abbreviation},
-								${c.citations.filter((c) => c.type == "official")[0].cite}
-								(${c.decision_date.substring(0, 4)})
-							</a>
-						</li>`,
-				)}
-			</ul>
+			<cap-caselaw-layout>
+				<div class="volumes__main">
+					<h1>${this.volume} ${this.reporterData.short_name}</h1>
+					<h2>
+						${this.reporterData.full_name}
+						(${this.reporterData.start_year}-${this.reporterData.end_year}) volume
+						${this.volume}
+					</h2>
+					<ul>
+						${this.casesData.map(
+							(c) =>
+								html`<li>
+									<a
+										href="/caselaw/?reporter=${this.reporter}&volume=${this
+											.volume}&case=${String(c.first_page).padStart(4, "0")}"
+									>
+										${c.name_abbreviation},
+										${c.citations.filter((c) => c.type == "official")[0].cite}
+										(${c.decision_date.substring(0, 4)})
+									</a>
+								</li>`,
+						)}
+					</ul>
+				</div>
+			</cap-caselaw-layout>
 		`;
 	}
 }

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -71,16 +71,15 @@ export default class CapVolume extends LitElement {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
-				margin-bottom: .5rem;
+				margin-bottom: 0.5rem;
 			}
 
 			.volume__caseList {
 				margin-block-start: var(--spacing-100);
 				display: block;
 			}
-		`
-	]
-
+		`,
+	];
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -103,11 +102,13 @@ export default class CapVolume extends LitElement {
 			<cap-caselaw-layout>
 				<div class="volumes__main">
 					<hgroup>
-						<h1 class="volume__heading">${this.volume} ${this.reporterData.short_name}</h1>
+						<h1 class="volume__heading">
+							${this.volume} ${this.reporterData.short_name}
+						</h1>
 						<p>
 							${this.reporterData.full_name}
-							(${this.reporterData.start_year}-${this.reporterData.end_year}) volume
-							${this.volume}.
+							(${this.reporterData.start_year}-${this.reporterData.end_year})
+							volume ${this.volume}.
 						</p>
 					</hgroup>
 					<ul class="volume__caseList">


### PR DESCRIPTION
This PR styles the volume pages that show all the cases.
The old version looks like this:
<img width="1714" alt="Screenshot 2024-01-29 at 10 39 05 AM" src="https://github.com/harvard-lil/capstone-static/assets/7401870/52b0dcd4-2df9-45b1-b2ae-62b9ca1b6190">

The new version looks like this:
<img width="1719" alt="Screenshot 2024-01-29 at 10 40 12 AM" src="https://github.com/harvard-lil/capstone-static/assets/7401870/df1da611-f241-428a-9c43-29e026f42505">

I also made a small tweak to the reporter pages that show all the volumes, to mirror an update I made on the volumes pages.