### PR TITLE
Make footer sticky.

### DIFF
--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -66,7 +66,7 @@
 		<cap-nav></cap-nav>
 		<main id="main">
 			<cap-content-router></cap-content-router>
-			<cap-footer></cap-footer>
 		</main>
+		<cap-footer></cap-footer>
 	</body>
 </html>

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -5,7 +5,15 @@
 @import "components.css";
 @import "utilities.css";
 
+html {
+	height: 100%;
+	min-height: 100%;
+}
+
 body {
+	min-height: 100%;
+	display: grid;
+	grid-template-rows: auto 1fr auto;
 	margin: 0;
 	-webkit-font-smoothing: antialiased;
 }

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -1,14 +1,3 @@
-html {
-	height: 100%;
-	min-height: 100%;
-}
-
-body {
-	min-height: 100%;
-	display: grid;
-	grid-template-rows: auto 1fr auto;
-}
-
 .l-interiorPage {
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -1,3 +1,14 @@
+html {
+	height: 100%;
+	min-height: 100%;
+}
+
+body {
+	min-height: 100%;
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+}
+
 .l-interiorPage {
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);

--- a/src/index.html
+++ b/src/index.html
@@ -72,7 +72,7 @@
 				<cap-section-highlight> </cap-section-highlight>
 				<cap-contact> </cap-contact>
 			</section>
-			<cap-footer></cap-footer>
 		</main>
+		<cap-footer></cap-footer>
 	</body>
 </html>


### PR DESCRIPTION
Technique from https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Sticky_footers

Before:
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/781c8b60-0002-4ff0-a1e4-f011a5c2271a)

After:
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/89e58cc9-4013-4aa5-bd1d-e217b1929f65)

Even though only the 404 page is affected at present, since it is the only short page, I moved the footer on the landing page and on the caselaw page, so that on every page, it is a sibling of `main` instead of a child of `main`, so that this CSS would work properly there, had they been shorter. (The footer was already a sibling of `main` on the gallery and about pages). 

With this change, an empty page, 
```
	<body>
		<cap-nav></cap-nav>
		<main id="main"></main>
		<cap-footer></cap-footer>
	</body>
```
looks like 
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/860fffac-80be-4bba-b07a-fa620d7a22fd)

instead of 
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/d13b89be-6bde-446c-ba64-02911f846f6a)


