### PR TITLE
Add reporter-, volume- and case-specific page titles.

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -432,6 +432,7 @@ export default class CapCase extends LitElement {
 		};
 		window.requestAnimationFrame(doNothing);
 		window.requestAnimationFrame(rewriteLinks);
+		window.document.title = `${this.createCaseHeaderHeader(this.caseMetadata)} | Caselaw Access Project`;
 		return html`
 			<div class="case-container">
 				<div class="case-header">

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -96,6 +96,7 @@ export default class CapReporter extends LitElement {
 	}
 
 	render() {
+		window.document.title = `Reporter: ${this.reporterData.short_name} | Caselaw Access Project`;
 		return html`
 			<cap-caselaw-layout>
 				<div class="reporters__main">

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -38,6 +38,7 @@ export default class CapVolume extends LitElement {
 
 	render() {
 		//todo this will need to be updated to deal with multiple cases on the same page
+		window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
 		return html`
 			<h1>${this.volume} ${this.reporterData.short_name}</h1>
 			<h2>


### PR DESCRIPTION
This PR reproduces the page titles currently served by CAP when browsing caselaw. Instead of "Caselaw | Caselaw Access Project":

- "Reporter: Ala. | Caselaw Access Project"
- "Volume: Ala. volume 1 | Caselaw Access Project"
- "[Full Citation] | Caselaw Access Project", e.g. "Branch Bank v. Harrison, 1 Ala. 9 (1840) | Caselaw Access Project"

~This PR is dependent on #36: it uses its [`createCaseHeaderHeader` method](https://github.com/harvard-lil/capstone-static/pull/36/files#diff-70912d178259655c1c5c61728a31bebd055cd245f5050aa841596e0655422771R384). I'll keep it in draft mode until that is merged.~