### PR TITLE
Remove nav to non-existent Terms and Privacy pages for now

### DIFF
--- a/src/data/nav.js
+++ b/src/data/nav.js
@@ -18,14 +18,14 @@ export const navLinks = [
 ];
 
 export const legalLinks = [
-	{
-		name: "Terms",
-		path: "/terms/",
-	},
-	{
-		name: "Privacy",
-		path: "/privacy/",
-	},
+	// {
+	// 	name: "Terms",
+	// 	path: "/terms/",
+	// },
+	// {
+	// 	name: "Privacy",
+	// 	path: "/privacy/",
+	// },
 	{
 		name: "Accessibility",
 		path: "https://accessibility.huit.harvard.edu/digital-accessibility-policy",


### PR DESCRIPTION
It is unclear whether the site needs a Terms page, a Privacy page, or both.

While that is up-in-the-air, this PR removes the broken nav links by commenting them out in the data file.

If it turns out we need them, we can put them back 😄 .