### PR TITLE
docs page

### DIFF
--- a/src/data/docsSidebarLinks.js
+++ b/src/data/docsSidebarLinks.js
@@ -7,4 +7,4 @@ export const anchorLinks = [
 		title: "Bulk Downloads",
 		url: "#bulk-downloads",
 	},
-]
+];

--- a/src/data/docsSidebarLinks.js
+++ b/src/data/docsSidebarLinks.js
@@ -1,0 +1,10 @@
+export const anchorLinks = [
+	{
+		title: "Accessing Data",
+		url: "#accessing-data",
+	},
+	{
+		title: "Bulk Downloads",
+		url: "#bulk-downloads",
+	},
+]

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Documentation | Caselaw Access Project</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<meta name="author" content="Your name" />
+		<meta name="description" content="Explore American Caselaw" />
+		<meta property="og:title" content="Caselaw Access Project" />
+		<meta property="og:description" content="Explore American Caselaw" />
+		<meta property="og:url" content="https://case.law/" />
+		<meta property="og:type" content="article" />
+		<meta property="og:site_name" content="Caselaw Access Projects" />
+
+		<link href="/css/global.css" rel="stylesheet" />
+		<script type="module" src="/templates/cap-docs-page.js"></script>
+	</head>
+	<body>
+		<cap-docs-page></cap-docs-page>
+	</body>
+</html>

--- a/src/templates/cap-docs-page.js
+++ b/src/templates/cap-docs-page.js
@@ -20,8 +20,8 @@ export class CapDocsPage extends LitElement {
 					<cap-page-header heading="Documentation">
 						<p class="u-text-white u-text-serif">
 							Welcome to the Caselaw Access Project Documentation. Here you'll
-							find some documentation about our project, organization, data,
-							applications, services, and site.
+							find some documentation about our project, organization, data, and
+							site.
 						</p>
 					</cap-page-header>
 				</header>

--- a/src/templates/cap-docs-page.js
+++ b/src/templates/cap-docs-page.js
@@ -1,0 +1,34 @@
+import { LitElement, html } from "../lib/lit.js";
+import "../components/cap-nav.js";
+import "../components/cap-page-header.js";
+import "../components/cap-footer.js";
+import "../components/cap-anchor-list.js";
+import "../components/cap-media-list.js";
+import "../components/cap-contributor-list.js";
+
+export class CapDocsPage extends LitElement {
+	// Turn Shadow DOM off
+	// Generally discouraged: https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot
+	createRenderRoot() {
+		return this;
+	}
+
+	render() {
+		return html`
+			<cap-nav></cap-nav>
+			<main id="main" class="l-interiorPage">
+				<header class="u-bg-gray-500 u-col-span-full">
+					<cap-page-header heading="Documentation">
+						<p class="u-text-white u-text-serif">
+							Welcome to the Caselaw Access Project Documentation.
+                            Here you'll find some documentation about our project,
+                            organization, data, applications, services, and site.
+						</p>
+					</cap-page-header>
+				</header>
+			</main>
+			<cap-footer></cap-footer>
+		`;
+	}
+}
+customElements.define("cap-docs-page", CapDocsPage);

--- a/src/templates/cap-docs-page.js
+++ b/src/templates/cap-docs-page.js
@@ -19,29 +19,25 @@ export class CapDocsPage extends LitElement {
 				<header class="u-bg-gray-500 u-col-span-full">
 					<cap-page-header heading="Documentation">
 						<p class="u-text-white u-text-serif">
-							Welcome to the Caselaw Access Project Documentation.
-                            Here you'll find some documentation about our project,
-                            organization, data, applications, services, and site.
+							Welcome to the Caselaw Access Project Documentation. Here you'll
+							find some documentation about our project, organization, data,
+							applications, services, and site.
 						</p>
 					</cap-page-header>
 				</header>
-                <aside class="u-sm-hidden">
+				<aside class="u-sm-hidden">
 					<cap-anchor-list .data=${anchorLinks}></cap-anchor-list>
 				</aside>
-                <article class="c-article u-bg-beige">
-					<h2 class="c-decoratedHeader" id="accessing-data">
-						Accessing Data
-					</h2>
+				<article class="c-article u-bg-beige">
+					<h2 class="c-decoratedHeader" id="accessing-data">Accessing Data</h2>
 					<p>
 						[We will put some documentation content about accessing data here.]
 					</p>
-                    <h2 class="c-decoratedHeader" id="bulk-downloads">
-						Bulk Downloads
-					</h2>
+					<h2 class="c-decoratedHeader" id="bulk-downloads">Bulk Downloads</h2>
 					<p>
 						[We will put some documentation content about bulk downloads here.]
 					</p>
-                </article>
+				</article>
 			</main>
 			<cap-footer></cap-footer>
 		`;

--- a/src/templates/cap-docs-page.js
+++ b/src/templates/cap-docs-page.js
@@ -3,8 +3,7 @@ import "../components/cap-nav.js";
 import "../components/cap-page-header.js";
 import "../components/cap-footer.js";
 import "../components/cap-anchor-list.js";
-import "../components/cap-media-list.js";
-import "../components/cap-contributor-list.js";
+import { anchorLinks } from "../data/docsSidebarLinks.js";
 
 export class CapDocsPage extends LitElement {
 	// Turn Shadow DOM off
@@ -26,6 +25,23 @@ export class CapDocsPage extends LitElement {
 						</p>
 					</cap-page-header>
 				</header>
+                <aside class="u-sm-hidden">
+					<cap-anchor-list .data=${anchorLinks}></cap-anchor-list>
+				</aside>
+                <article class="c-article u-bg-beige">
+					<h2 class="c-decoratedHeader" id="accessing-data">
+						Accessing Data
+					</h2>
+					<p>
+						[We will put some documentation content about accessing data here.]
+					</p>
+                    <h2 class="c-decoratedHeader" id="bulk-downloads">
+						Bulk Downloads
+					</h2>
+					<p>
+						[We will put some documentation content about bulk downloads here.]
+					</p>
+                </article>
 			</main>
 			<cap-footer></cap-footer>
 		`;


### PR DESCRIPTION
This PR creates a Documentation page that looks like the About and Gallery pages and contains some placeholder content that will be filled in later.
It looks like this:
<img width="1693" alt="Screenshot 2024-01-31 at 10 22 35 AM" src="https://github.com/harvard-lil/capstone-static/assets/7401870/5c29611e-6bc7-4a4c-946b-470467e8b3ed">
