### PR TITLE
Add breadcrumb component

### DIFF
--- a/src/components/cap-breadcrumb.js
+++ b/src/components/cap-breadcrumb.js
@@ -31,6 +31,7 @@ export class CapBreadcrumb extends LitElement {
 
 			.list {
 				display: flex;
+				flex-wrap: wrap;
 				list-style: none;
 				margin: 0;
 				padding: 0;

--- a/src/components/cap-breadcrumb.js
+++ b/src/components/cap-breadcrumb.js
@@ -1,0 +1,93 @@
+import { LitElement, html, css, nothing } from "../lib/lit.js";
+import { baseStyles } from "../lib/wc-base.js";
+
+export class CapBreadcrumb extends LitElement {
+	static properties = {
+		navItems: { type: Array },
+	};
+
+	static styles = [
+		baseStyles,
+		css`
+			.breadcrumb {
+				font-family: var(--font-sans-text);
+				font-size: var(--font-size-100);
+				padding: var(--spacing-150);
+				background: var(--color-gray-100);
+			}
+
+			.list {
+				display: flex;
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+
+			.list__item {
+				display: flex;
+				align-items: center;
+				margin-inline-end: var(--spacing-75);
+			}
+
+			.list__item:not(:last-child)::after {
+				content: "";
+				display: block;
+				height: 0.8125rem;
+				width: 0.3125rem;
+				background: url('data:image/svg+xml,<svg width="5" height="13" viewBox="0 0 5 13" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.139893 12.2401L3.87789 0.0600586H4.71789L0.979893 12.2401H0.139893Z" fill="%236C757D"/></svg>');
+				margin-inline-start: var(--spacing-75);
+			}
+
+			a:link,
+			a:visited,
+			a:hover,
+			a:active {
+				text-decoration: none;
+				color: var(--color-blue-400);
+			}
+
+			a:hover {
+				text-decoration: underline;
+			}
+
+			.breadcrumb [aria-current] {
+				color: var(--color-gray-500);
+			}
+		`,
+	];
+
+	constructor() {
+		super();
+		this.navItems = [];
+	}
+
+	render() {
+		return html`
+			<nav aria-label="Breadcrumb" class="breadcrumb">
+				<ol class="list">
+					<li class="list__item">
+						<a href="/"> Home</a>
+					</li>
+					<li class="list__item">
+						<a href="/caselaw"> Caselaw </a>
+					</li>
+					${this.navItems.map(
+						(navItem, index) =>
+							html`<li class="list__item">
+								<a
+									href=${navItem.url}
+									aria-current=${index + 1 === this.navItems.length
+										? "page"
+										: nothing}
+								>
+									${navItem.name}
+								</a>
+							</li>`,
+					)}
+				</ol>
+			</nav>
+		`;
+	}
+}
+
+customElements.define("cap-breadcrumb", CapBreadcrumb);

--- a/src/components/cap-breadcrumb.js
+++ b/src/components/cap-breadcrumb.js
@@ -63,7 +63,7 @@ export class CapBreadcrumb extends LitElement {
 
 	render() {
 		return html`
-			<nav aria-label="Breadcrumb" class="breadcrumb">
+			<nav aria-label="breadcrumbs" class="breadcrumb">
 				<ol class="list">
 					<li class="list__item">
 						<a href="/"> Home</a>

--- a/src/components/cap-breadcrumb.js
+++ b/src/components/cap-breadcrumb.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css, nothing } from "../lib/lit.js";
 import { baseStyles } from "../lib/wc-base.js";
+import clsx from "../lib/clsx.js";
 
 export class CapBreadcrumb extends LitElement {
 	static properties = {
@@ -9,6 +10,18 @@ export class CapBreadcrumb extends LitElement {
 	static styles = [
 		baseStyles,
 		css`
+			a:link,
+			a:visited,
+			a:hover,
+			a:active {
+				text-decoration: none;
+				color: var(--color-blue-400);
+			}
+
+			a:hover {
+				text-decoration: underline;
+			}
+
 			.breadcrumb {
 				font-family: var(--font-sans-text);
 				font-size: var(--font-size-100);
@@ -24,34 +37,17 @@ export class CapBreadcrumb extends LitElement {
 			}
 
 			.list__item {
-				display: flex;
-				align-items: center;
 				margin-inline-end: var(--spacing-75);
+				font-size: var(--font-size-100);
 			}
 
-			.list__item:not(:last-child)::after {
-				content: "";
-				display: block;
-				height: 0.8125rem;
-				width: 0.3125rem;
-				background: url('data:image/svg+xml,<svg width="5" height="13" viewBox="0 0 5 13" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.139893 12.2401L3.87789 0.0600586H4.71789L0.979893 12.2401H0.139893Z" fill="%236C757D"/></svg>');
+			.list__item--current {
+				font-weight: 600;
+			}
+
+			.list__divider {
 				margin-inline-start: var(--spacing-75);
-			}
-
-			a:link,
-			a:visited,
-			a:hover,
-			a:active {
-				text-decoration: none;
-				color: var(--color-blue-400);
-			}
-
-			a:hover {
-				text-decoration: underline;
-			}
-
-			.breadcrumb [aria-current] {
-				color: var(--color-gray-500);
+				color: var(--color-gray-300);
 			}
 		`,
 	];
@@ -67,23 +63,28 @@ export class CapBreadcrumb extends LitElement {
 				<ol class="list">
 					<li class="list__item">
 						<a href="/"> Home</a>
+						<span class="list__divider" aria-hidden="true">/</span>
 					</li>
 					<li class="list__item">
-						<a href="/caselaw"> Caselaw </a>
+						<a href="/caselaw"> Caselaw</a>
+						<span class="list__divider" aria-hidden="true">/</span>
 					</li>
-					${this.navItems.map(
-						(navItem, index) =>
-							html`<li class="list__item">
-								<a
-									href=${navItem.url}
-									aria-current=${index + 1 === this.navItems.length
-										? "page"
-										: nothing}
-								>
-									${navItem.name}
-								</a>
-							</li>`,
-					)}
+					${this.navItems.map((navItem, index) => {
+						const isCurrent = index + 1 === this.navItems.length;
+						return html`<li
+							class=${clsx("list__item", { "list__item--current": isCurrent })}
+						>
+							<a
+								href=${navItem.url}
+								aria-current=${isCurrent ? "page" : nothing}
+							>
+								${navItem.name}
+							</a>
+							${isCurrent
+								? nothing
+								: html`<span class="list__divider" aria-hidden="true">/</span>`}
+						</li>`;
+					})}
 				</ol>
 			</nav>
 		`;

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -54,12 +54,12 @@ export default class CapReporter extends LitElement {
 			.reporters__main {
 				grid-column: 1 / -1;
 				padding-inline: var(--spacing-500);
-				padding-block-start: var(--spacing-300);
+				padding-block-start: var(--spacing-400);
 				padding-block-end: var(--spacing-550);
-
-				@media (min-width: 60rem) {
-					grid-column: 1 / -1;
 				}
+
+			.reporter__headingGroup {
+				margin-block-start: var(--spacing-100);
 			}
 
 			.reporter__heading {
@@ -70,7 +70,6 @@ export default class CapReporter extends LitElement {
 
 			.reporter__subHeading {
 				font-size: var(--font-size-175);
-				margin-block-start: var(--spacing-0);
 				font-weight: 500;
 			}
 
@@ -79,7 +78,7 @@ export default class CapReporter extends LitElement {
 				display: block;
 			}
 
-			.list__title {
+			.reporter__volumeTitle {
 				font-weight: 600;
 			}
 		`,
@@ -95,7 +94,7 @@ export default class CapReporter extends LitElement {
 		return html`
 			<cap-caselaw-layout>
 				<div class="reporters__main">
-					<hgroup>
+					<hgroup class="reporter__headingGroup">
 						<h1 class="reporter__heading">${this.reporterData.short_name}</h1>
 						<p class="reporter__subHeading">
 							${this.reporterData.full_name}
@@ -103,7 +102,7 @@ export default class CapReporter extends LitElement {
 						</p>
 					</hgroup>
 					<ul class="reporter__volumeList">
-						<p class="list__title">Volume number:</p>
+						<p class="reporter__volumeTitle">Volume number:</p>
 						${this.volumesData
 							.sort((a, b) => a.volume_number - b.volume_number)
 							.map(

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -1,6 +1,11 @@
 import { LitElement, html, css } from "../lib/lit.js";
-import { fetchVolumesData, fetchReporterData } from "../lib/data.js";
+import {
+	fetchVolumesData,
+	fetchReporterData,
+	getBreadcrumbLinks,
+} from "../lib/data.js";
 import { baseStyles } from "../lib/wc-base.js";
+import "./cap-breadcrumb.js";
 
 export default class CapReporter extends LitElement {
 	static properties = {
@@ -56,7 +61,7 @@ export default class CapReporter extends LitElement {
 				padding-inline: var(--spacing-500);
 				padding-block-start: var(--spacing-400);
 				padding-block-end: var(--spacing-550);
-				}
+			}
 
 			.reporter__headingGroup {
 				margin-block-start: var(--spacing-100);
@@ -94,6 +99,9 @@ export default class CapReporter extends LitElement {
 		return html`
 			<cap-caselaw-layout>
 				<div class="reporters__main">
+					<cap-breadcrumb
+						.navItems=${getBreadcrumbLinks(this.reporterData)}
+					></cap-breadcrumb>
 					<hgroup class="reporter__headingGroup">
 						<h1 class="reporter__heading">${this.reporterData.short_name}</h1>
 						<p class="reporter__subHeading">

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -56,7 +56,7 @@ export default class CapReporter extends LitElement {
 				text-decoration: underline;
 			}
 
-			.reporters__main {
+			.reporter {
 				grid-column: 1 / -1;
 				padding-inline: var(--spacing-500);
 				padding-block-start: var(--spacing-400);
@@ -98,7 +98,7 @@ export default class CapReporter extends LitElement {
 		window.document.title = `Reporter: ${this.reporterData.short_name} | Caselaw Access Project`;
 		return html`
 			<cap-caselaw-layout>
-				<div class="reporters__main">
+				<div class="reporter">
 					<cap-breadcrumb
 						.navItems=${getBreadcrumbLinks(this.reporterData)}
 					></cap-breadcrumb>

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -56,30 +56,30 @@ export default class CapVolume extends LitElement {
 				text-decoration: underline;
 			}
 
-			.volumes__main {
+			.volume__main {
 				grid-column: 1 / -1;
 				padding-inline: var(--spacing-500);
-				padding-block-start: var(--spacing-300);
+				padding-block-start: var(--spacing-400);
 				padding-block-end: var(--spacing-550);
-
-				@media (min-width: 60rem) {
-					grid-column: 1 / -1;
 				}
+
+			.volume__headingGroup {
+				margin-block-start: var(--spacing-100);
 			}
 
-			.volume__heading {
+			.volumes__heading {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
 			}
 
-			.volume__subHeading {
+			.volumes__subHeading {
 				font-size: var(--font-size-175);
 				margin-block-start: var(--spacing-0);
 				font-weight: 500;
 			}
 
-			.volume__caseList {
+			.volumes__caseList {
 				margin-block-start: var(--spacing-150);
 				display: block;
 			}
@@ -106,8 +106,8 @@ export default class CapVolume extends LitElement {
 		window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
 		return html`
 			<cap-caselaw-layout>
-				<div class="volumes__main">
-					<hgroup>
+				<div class="volume__main">
+					<hgroup class="volume__headingGroup">
 						<h1 class="volume__heading">
 							${this.volume} ${this.reporterData.short_name}
 						</h1>

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -58,7 +58,7 @@ export default class CapVolume extends LitElement {
 				text-decoration: underline;
 			}
 
-			.volume__main {
+			.volume {
 				grid-column: 1 / -1;
 				padding-inline: var(--spacing-500);
 				padding-block-start: var(--spacing-400);
@@ -108,7 +108,7 @@ export default class CapVolume extends LitElement {
 		window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
 		return html`
 			<cap-caselaw-layout>
-				<div class="volume__main">
+				<div class="volume">
 					<cap-breadcrumb
 						.navItems=${getBreadcrumbLinks(this.reporterData, this.volume)}
 					></cap-breadcrumb>

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -3,8 +3,10 @@ import {
 	fetchCasesList,
 	fetchReporterData,
 	fetchVolumeData,
+	getBreadcrumbLinks,
 } from "../lib/data.js";
 import { baseStyles } from "../lib/wc-base.js";
+import "./cap-breadcrumb.js";
 
 export default class CapVolume extends LitElement {
 	static properties = {
@@ -61,25 +63,25 @@ export default class CapVolume extends LitElement {
 				padding-inline: var(--spacing-500);
 				padding-block-start: var(--spacing-400);
 				padding-block-end: var(--spacing-550);
-				}
+			}
 
 			.volume__headingGroup {
 				margin-block-start: var(--spacing-100);
 			}
 
-			.volumes__heading {
+			.volume__heading {
 				font-weight: 600;
 				font-size: var(--font-size-250);
 				position: relative;
 			}
 
-			.volumes__subHeading {
+			.volume__subHeading {
 				font-size: var(--font-size-175);
 				margin-block-start: var(--spacing-0);
 				font-weight: 500;
 			}
 
-			.volumes__caseList {
+			.volume__caseList {
 				margin-block-start: var(--spacing-150);
 				display: block;
 			}
@@ -107,6 +109,9 @@ export default class CapVolume extends LitElement {
 		return html`
 			<cap-caselaw-layout>
 				<div class="volume__main">
+					<cap-breadcrumb
+						.navItems=${getBreadcrumbLinks(this.reporterData, this.volume)}
+					></cap-breadcrumb>
 					<hgroup class="volume__headingGroup">
 						<h1 class="volume__heading">
 							${this.volume} ${this.reporterData.short_name}

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -4,7 +4,7 @@
 	--font-size-50: 0.685rem;
 	--font-size-75: 0.75rem;
 	--font-size-100: 0.875rem;
-	--font-size-125: 1 rem;
+	--font-size-125: 1rem;
 	--font-size-150: 1.125rem;
 	--font-size-175: 1.25rem;
 	--font-size-200: 1.5rem;

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,9 +1,9 @@
 @import "fonts.css";
 
 :root {
-	--font-size-50: 0.685 rem;
-	--font-size-75: 0.75 rem;
-	--font-size-100: 0.875 rem;
+	--font-size-50: 0.685rem;
+	--font-size-75: 0.75rem;
+	--font-size-100: 0.875rem;
 	--font-size-125: 1 rem;
 	--font-size-150: 1.125rem;
 	--font-size-175: 1.25rem;

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -62,3 +62,22 @@ const fetchJson = async (url) => {
 	const response = await fetch(url);
 	return await response.json();
 };
+
+export const getBreadcrumbLinks = (reporterData, volume) => {
+	const reporterLink = {
+		url: `/caselaw/?reporter=${reporterData.slug}`,
+		name: `Reporter ${reporterData.short_name}`,
+	};
+
+	if (volume) {
+		return [
+			reporterLink,
+			{
+				url: `/caselaw/?reporter=${reporterData.slug}&volume=${volume}`,
+				name: `Volume ${volume}`,
+			},
+		];
+	}
+
+	return [reporterLink];
+};


### PR DESCRIPTION
## Summary
Adds a new breadcrumb component the volume and reporter pages. The breadcrumb component is intended to be relatively similar to the visually style of the current breadcrumb component on case.law, but with some improvements for accessibility:

- Specifically, the breadcrumb now includes homepage and the caselaw routes in its list of links
- The current page is visually offset, in a bold weight
- Each breadcrumb link now has a visible hover state, that does not rely on color for disambiguation

Some other key aspects of the breadcrumb component:

- From a semantic point of view, the breadcrumb is also now marked up as a nav element that contains an ordered list. 
- Per accessibility guidelines, the dividers separating each link are hidden from screenreaders. I noticed some examples of accessible breadcrumbs use the `content` property of pseudo elements to display these, but screenreaders do read content out loud, and there is not yet a fully browser-compatible way for it to not. 
- The link that matches the current page has an aria attribute, `aria-page="current"`

## What this changes
- Adds new web component, `cap-breadcrumb.js`
- Finesses the styles of the `cap-reporter.js` and `cap-volume.js` pages
- Fixes an issue with spacing in `typography.css` — there was a extra space inbetween a font-size value and the word rem
- Adds a utility function, `getBreadcrumbLinks` to `lib.js`

## Screenshots
<img width="1290" alt="Screenshot 2024-02-01 at 11 26 26 AM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/8ef58259-040f-4abc-af13-e0c0b06ea645" alt="a screenshot of the volume page">
<img width="1283" alt="Screenshot 2024-02-01 at 11 26 17 AM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/7a36cffc-f860-4da4-bdac-373e9552d560" alt="a screenshot of the reporter page">
