### PR TITLE
a11y tweak: keyboard focus + in-page anchors

### DIFF
--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -130,7 +130,9 @@ export default class CapJurisdictions extends LitElement {
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
+				element.tabIndex = -1;
 				element.scrollIntoView();
+				element.focus();
 			}
 		}
 	}


### PR DESCRIPTION
This tweaks the existing fix for navigating to in-page hashes whose targets are elements in the ShadowDOM. The existing fix scrolls the viewport; this moves keyboard focus as well. 