### PR TITLE
Citation + Case Links

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -1,6 +1,10 @@
 import { LitElement, html, css, unsafeHTML, nothing } from "../lib/lit.js";
 
-import { fetchCaselawBody, fetchCaseMetadata } from "../lib/data.js";
+import {
+	fetchCaselawBody,
+	fetchCaseMetadata,
+	fetchCasesList,
+} from "../lib/data.js";
 
 export default class CapCase extends LitElement {
 	static properties = {
@@ -411,6 +415,104 @@ export default class CapCase extends LitElement {
 		}
 	}
 
+	removeLink = (a) => {
+		a.replaceWith(a.innerHTML);
+	};
+
+	doNothing = () => {};
+
+	rewriteLinks = () => {
+		this.shadowRoot.querySelectorAll("a").forEach((a) => {
+			const oldLink = a.getAttribute("href");
+			// skip links without hrefs or that point back at the same page
+			if (!oldLink || oldLink.startsWith("#")) {
+				return;
+			}
+			const oldUrl = new URL(oldLink);
+			if (oldUrl.hostname === "cite.case.law") {
+				const pathComponents = oldUrl.pathname
+					.split("/")
+					.filter((x) => x !== ""); // remove empty strings
+				if (pathComponents.length === 3) {
+					/*
+					Case: https://cite.case.law/ill-app-3d/16/850/
+					This represents a citation to a particular page
+					where only one case starts.
+					*/
+					const [reporter, volume, page] = pathComponents;
+					//http://localhost:5501/caselaw/?reporter=ark-app&volume=12&case=0028
+					const newUrl = new URL(
+						`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-01`,
+						window.location,
+					);
+					a.setAttribute("href", newUrl);
+					return;
+				} else if (pathComponents.length === 4) {
+					/*
+					Case: https://cite.case.law/mass/400/1006/880059/
+					This represents a citation to a particular page
+					where more than one case begins, so an
+					additional disambiguating suffix is added to
+					the URL. We need to translate that to the ordinal
+					number of the case on the page.
+					*/
+					const [reporter, volume, page, caseId] = pathComponents;
+
+					// First we need to load CasesMetadata for the cited case
+					new Promise((resolve, reject) => {
+						fetchCasesList(reporter, volume, (data) => {
+							try {
+								resolve(data);
+							} catch (e) {
+								console.log("Couldn't look this one up.");
+								reject(e);
+							}
+						});
+					}).then(
+						(casesList) => {
+							// find all the cases that begin on this page
+							const casesOnPage = casesList.filter(
+								(x) => x.first_page === page,
+							);
+
+							//find the index in the casesOn page of the case we're looking for
+							const index = casesOnPage.findIndex(
+								(x) => x.id.toString() === caseId,
+							);
+
+							// construct the proper link to the case
+							const newUrl = new URL(
+								`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-${(index + 1).toString().padStart(2, "0")}`,
+								window.location,
+							);
+
+							///set the href of the link to the new url
+							a.setAttribute("href", newUrl);
+						},
+						(error) => {
+							// Got an error looking up the CasesMetadata. Remove the link because we can't resolve it
+							this.removeLink(a);
+							return;
+						},
+					);
+					return;
+				} else if (oldUrl.searchParams.has("q")) {
+					/*
+					Case: https://cite.case.law/citations/?q=42%20U.S.C.%20%C2%A7%201983
+					This represents a link to a statute we
+					don't actually have the copy for, so
+					instead, we do a search on other cases
+					that cite the same statute. We'll remove
+					this.
+					*/
+					this.removeLink(a);
+					return;
+				}
+			}
+			// We don't know what this url is, so leave it be.
+		});
+	};
+
 	render() {
 		/*
 		This render method uses requestAnimationFrame to alter the links in
@@ -420,20 +522,11 @@ export default class CapCase extends LitElement {
 		*/
 
 		// Skip the first frame which is the shadow DOM render
-		const doNothing = () => {};
+		window.requestAnimationFrame(this.doNothing);
 		// Rewrite the links on the second frame
-		const rewriteLinks = () => {
-			this.shadowRoot.querySelectorAll("a").forEach((a) => {
-				const oldLink = a.getAttribute("href");
-				// skip links without hrefs or that point back at the same page
-				if (!!oldLink && !oldLink.startsWith("#")) {
-					a.href = oldLink + "#todo";
-				}
-			});
-		};
-		window.requestAnimationFrame(doNothing);
-		window.requestAnimationFrame(rewriteLinks);
 		window.document.title = `${this.createCaseHeaderHeader(this.caseMetadata)} | Caselaw Access Project`;
+		window.requestAnimationFrame(this.rewriteLinks);
+
 		return html`
 			<div class="case-container">
 				<div class="case-header">

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -425,9 +425,10 @@ export default class CapCase extends LitElement {
 		const rewriteLinks = () => {
 			this.shadowRoot.querySelectorAll("a").forEach((a) => {
 				const oldLink = a.getAttribute("href");
-				//todo we need to fix this when ENG-523 happens
-				// (and we should make sure we don't break footnotes when we do)
-				a.href = oldLink + "#todo";
+				// skip links without hrefs or that point back at the same page
+				if (!!oldLink && !oldLink.startsWith("#")) {
+					a.href = oldLink + "#todo";
+				}
 			});
 		};
 		window.requestAnimationFrame(doNothing);

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -102,7 +102,6 @@ export default class CapVolume extends LitElement {
 	}
 
 	render() {
-		//todo this will need to be updated to deal with multiple cases on the same page
 		window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
 		return html`
 			<cap-caselaw-layout>
@@ -123,7 +122,10 @@ export default class CapVolume extends LitElement {
 								html`<li>
 									<a
 										href="/caselaw/?reporter=${this.reporter}&volume=${this
-											.volume}&case=${String(c.first_page).padStart(4, "0")}"
+											.volume}&case=${String(c.first_page).padStart(
+											4,
+											"0",
+										)}-${String(c.ordinal).padStart(2, "0")}"
 									>
 										${c.name_abbreviation},
 										${c.citations.filter((c) => c.type == "official")[0].cite}

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -30,7 +30,26 @@ export const fetchVolumeData = async (reporter, volume, callback) => {
 
 export const fetchCasesList = async (reporter, volume, callback) => {
 	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/CasesMetadata.json`;
-	callback(await fetchJson(url));
+	const rawJson = await fetchJson(url);
+
+	// This sets the ordinal property on each case to the order in which it appears on the page.
+	// Usually 1 because there's only one case starting on a page.
+	const combined = new Map();
+	rawJson.forEach((element) => {
+		if (combined.has(element.first_page)) {
+			combined.get(element.first_page).push(element);
+		} else {
+			combined.set(element.first_page, [element]);
+		}
+	});
+	for (const key of combined.keys()) {
+		let index = 0;
+		for (const element of combined.get(key)) {
+			index += 1;
+			element.ordinal = index;
+		}
+	}
+	callback(rawJson);
 };
 
 export const fetchCaselawBody = async (

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -39,9 +39,7 @@ export const fetchCaselawBody = async (
 	caseName,
 	callback,
 ) => {
-	// TODO this is a hack to get around the fact that we don't have the case ordinal yet.
-	// See: ENG-522, ENG-523, ENG-533, and ENG-558
-	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/html/${caseName}-01.html`;
+	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/html/${caseName}.html`;
 	const response = await fetch(url);
 	callback(await response.text());
 };
@@ -52,10 +50,8 @@ export const fetchCaseMetadata = async (
 	caseName,
 	callback,
 ) => {
-	// TODO this is a hack to get around the fact that we don't have the case ordinal yet.
-	// See: ENG-522, ENG-523, ENG-533, and ENG-558
-	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/cases/${caseName}-01.json`;
-	callback(await fetchJson(url));
+	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/cases/${caseName}.json`;
+	callback(await fetchJson(url)); //here return {} if it didn't fetch
 };
 
 export const fetchMapData = async (callback) => {


### PR DESCRIPTION
This PR addresses ENG-548 and ENG-558.

These are two interrelated issues that relate to issues about how to link to a case. In a particular circumstance where two cases begin on the same page, we've decided to deal with this in the new version of the site by calling the case "[pagenumber]-[ordinal]", where `pagenumber` is the page where the case starts, and `ordinal` is the order in which the case appears on the page.

Previously, these were called "[pagenumber]/[caseId]", but in the static export of CAP, that link structure doesn't encode the same amount of information.

This means that all the cases linked to from the volumes page need to know which ordinal they are. Previously, we were hardcoding that as 1, so links to cases that were #2 or onward didn't work right. This was difficult to notice because it only happens rarely.

Additionally, all the citation links embedded in the HTML link out to https://cite.case.law, which is the legacy live site, and they use the old way of pathing to a case.

Lastly, some citation links in the corpus link to search queries to find related cases rather than linking directly to the cited document, because we don't actually have a copy of the document cited in the corpus. Since there will no longer be an API in the new site, these links are being removed.

This PR largely resolves these problems. The one remaining problem is that the vast majority of citations point at cases we don't have in R2 yet, because they're still in embargo. When this code attempts to load CaseMetadata.json for these cases, it discovers it doesn't have access to the data, and instead removes the link entirely. As the data fills in, this behavior will no longer happen.


How to test:

I. Citations

These links are rewritten in the HTML after the HTML is rendered on the page using the requestAnimationFrame() method Matteo suggested. There are three cases of citation links that need to be handled. Note that plain anchor links in the existing page are now now longer mangled.

Case 1: Citation links when there's one unique case that starts on that page
On page http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=131&case=0548-01
The citation 102 Ill.App.2d 166
Should link to http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=102&case=0166-01


Case 2: Linking when two cases start on the same page

On page http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=131&case=0548-01#p550
The citation "131 Ill.App.2d 121"
Should link to http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=131&case=0121-02

NOTE: You will currently be able to find citations to cases where we currently aren't hosting them. These links are also removed becuase loading CaseMetadata.json for that volume fails, and we paper over it by removing the link.


Case 3: The citation was a search link to cases that also cite the same case.

The citation 239 N.E.2d 690
Should not be linked. (The link was removed)


II. Volume list

The hack for dealing with the situation where two cases start on the same page has been removed, and now cases linked to from the Volume page have the correct ordinal suffix. 

On page: http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=131
The case "People v. Reynolds, 131 Ill. App. 2d 121 (1970)"
Should link to http://localhost:5501/caselaw/?reporter=ill-app-2d&volume=131&case=0121-02


Errata:

Ideally I wouldn't be attempting to load the CaseMetadata.json for every link on the page, since citations are often repeated. I tested in Lighthouse and didn't really see it flagging this for performance reasons, however. The browser is likely re-serving the JSON from cache.

I'm also open to feedback that this new JS should live outside of the page, since it visually bloats the page by quite a bit.

Please let me know if you have any questions!
