### PR TITLE
Replace color-gray-300 with the value assigned to color-gray-000

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -58,7 +58,7 @@ export default class CapCase extends LitElement {
 
 				.case-header::after {
 					content: "*";
-					color: var(--color-gray-000);
+					color: var(--color-gray-300);
 				}
 			}
 
@@ -145,7 +145,7 @@ export default class CapCase extends LitElement {
 				font-family: var(--font-serif);
 				margin-left: 0;
 				padding: 0.5rem 1rem 0.5rem 1rem;
-				border-left: 0.5rem solid var(--color-gray-000);
+				border-left: 0.5rem solid var(--color-gray-300);
 				color: var(--color-blue-500);
 				font-size: 0.875rem;
 				line-height: 1.5;
@@ -189,7 +189,7 @@ export default class CapCase extends LitElement {
 				padding-left: 0;
 				font-family: var(--font-sans-titling);
 				font-weight: bold;
-				color: var(--color-gray-000);
+				color: var(--color-gray-300);
 				word-break: break-all;
 				text-align: left;
 				font-size: 1rem;
@@ -203,7 +203,7 @@ export default class CapCase extends LitElement {
 				padding-left: 0;
 				font-family: var(--font-sans-titling);
 				font-weight: bold;
-				color: var(--color-gray-000);
+				color: var(--color-gray-300);
 				word-break: break-all;
 				text-align: left;
 				font-size: 1rem;
@@ -322,7 +322,7 @@ export default class CapCase extends LitElement {
 			}
 
 			.page-label {
-				color: var(--color-gray-000);
+				color: var(--color-gray-300);
 				font-size: 0.8em;
 				padding: 0.4em;
 				font-style: italic;

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -2,10 +2,9 @@
 	--color-white: #ffffff;
 	--color-beige: #f7f6f2;
 
-	--color-gray-000: #979797;
 	--color-gray-100: #f7f7f9;
 	--color-gray-200: #ced4da;
-	--color-gray-300: #6c757d;
+	--color-gray-300: #979797;
 	--color-gray-400: #495057;
 	--color-gray-500: #2f2f2f;
 	--color-gray-600: #000000;


### PR DESCRIPTION
## What this does 
This makes some revisions to the CSS variable color scale for consistency.  The current scale for colors follows a naming system where 100 is the lightest saturation and the highest number is the highest saturation / deepest shade.

One light shade of gray required by the CAP case page wasn't previously provided by the current color scale and was added as a placeholder as gray-000. This PR renames the variable from color-gray-000 to color-gray-300, for consistency with the rest of the scale. 

## Notes 
My initial strategy for this refactor was to do a find and replace for grays 300-600, starting with gray 600 and working backwards, and increment each variable's name by 100 (for example, gray-600 would become gray-700). However, after looking more closely at the codebase I noticed that gray-300 was not currently in use anywhere in the codebase. 

Based on this information, I think it might be easiest to simply swap the previous value associated with gray-300 with the gray required by the case page, because any future work on the website should most likely follow existing cap-static layouts and existing styles. And we can easily revisit this in the future if it turns out that we do have a need for the original gray-300. 

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to: 

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout update-css-variable` to checkout this branch 