### PR TITLE
404 if reporter, volume, or cases fails to load

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -6,6 +6,8 @@ import {
 	fetchCasesList,
 } from "../lib/data.js";
 
+import { fetchOr404 } from "../lib/fetchOr404.js";
+
 export default class CapCase extends LitElement {
 	static properties = {
 		caseBody: { attribute: false },
@@ -352,19 +354,20 @@ export default class CapCase extends LitElement {
 
 	connectedCallback() {
 		super.connectedCallback();
-		fetchCaselawBody(
-			this.reporter,
-			this.volume,
-			this.case,
-			(data) => (this.caseBody = data),
-		);
-
-		fetchCaseMetadata(
-			this.reporter,
-			this.volume,
-			this.case,
-			(data) => (this.caseMetadata = data),
-		);
+		fetchOr404(
+			() => fetchCaselawBody(
+				this.reporter,
+				this.volume,
+				this.case,
+				(data) => (this.caseBody = data),
+			),
+			() => fetchCaseMetadata(
+				this.reporter,
+				this.volume,
+				this.case,
+				(data) => (this.caseMetadata = data),
+			)
+		)
 	}
 
 	getYearFromDate(str) {

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -355,19 +355,21 @@ export default class CapCase extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		fetchOr404(
-			() => fetchCaselawBody(
-				this.reporter,
-				this.volume,
-				this.case,
-				(data) => (this.caseBody = data),
-			),
-			() => fetchCaseMetadata(
-				this.reporter,
-				this.volume,
-				this.case,
-				(data) => (this.caseMetadata = data),
-			)
-		)
+			() =>
+				fetchCaselawBody(
+					this.reporter,
+					this.volume,
+					this.case,
+					(data) => (this.caseBody = data),
+				),
+			() =>
+				fetchCaseMetadata(
+					this.reporter,
+					this.volume,
+					this.case,
+					(data) => (this.caseMetadata = data),
+				),
+		);
 	}
 
 	getYearFromDate(str) {

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -92,9 +92,11 @@ export default class CapReporter extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		fetchOr404(
-			() => fetchVolumesData(this.reporter, (data) => (this.volumesData = data)),
-			() => fetchReporterData(this.reporter, (data) => (this.reporterData = data))
-		)
+			() =>
+				fetchVolumesData(this.reporter, (data) => (this.volumesData = data)),
+			() =>
+				fetchReporterData(this.reporter, (data) => (this.reporterData = data)),
+		);
 	}
 
 	render() {

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -4,6 +4,7 @@ import {
 	fetchReporterData,
 	getBreadcrumbLinks,
 } from "../lib/data.js";
+import { fetchOr404 } from "../lib/fetchOr404.js";
 import { baseStyles } from "../lib/wc-base.js";
 import "./cap-breadcrumb.js";
 
@@ -90,8 +91,10 @@ export default class CapReporter extends LitElement {
 	];
 	connectedCallback() {
 		super.connectedCallback();
-		fetchVolumesData(this.reporter, (data) => (this.volumesData = data));
-		fetchReporterData(this.reporter, (data) => (this.reporterData = data));
+		fetchOr404(
+			() => fetchVolumesData(this.reporter, (data) => (this.volumesData = data)),
+			() => fetchReporterData(this.reporter, (data) => (this.reporterData = data))
+		)
 	}
 
 	render() {

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -5,6 +5,7 @@ import {
 	fetchVolumeData,
 	getBreadcrumbLinks,
 } from "../lib/data.js";
+import { fetchOr404 } from "../lib/fetchOr404.js";
 import { baseStyles } from "../lib/wc-base.js";
 import "./cap-breadcrumb.js";
 
@@ -90,17 +91,19 @@ export default class CapVolume extends LitElement {
 
 	connectedCallback() {
 		super.connectedCallback();
-		fetchCasesList(
-			this.reporter,
-			this.volume,
-			(data) => (this.casesData = data),
-		);
-		fetchReporterData(this.reporter, (data) => (this.reporterData = data));
-		fetchVolumeData(
-			this.reporter,
-			this.volume,
-			(data) => (this.volumeData = data),
-		);
+		fetchOr404(
+			() => fetchCasesList(
+				this.reporter,
+				this.volume,
+				(data) => (this.casesData = data),
+			),
+			() => fetchReporterData(this.reporter, (data) => (this.reporterData = data)),
+			() => fetchVolumeData(
+				this.reporter,
+				this.volume,
+				(data) => (this.volumeData = data),
+			)
+		)
 	}
 
 	render() {

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -92,18 +92,21 @@ export default class CapVolume extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		fetchOr404(
-			() => fetchCasesList(
-				this.reporter,
-				this.volume,
-				(data) => (this.casesData = data),
-			),
-			() => fetchReporterData(this.reporter, (data) => (this.reporterData = data)),
-			() => fetchVolumeData(
-				this.reporter,
-				this.volume,
-				(data) => (this.volumeData = data),
-			)
-		)
+			() =>
+				fetchCasesList(
+					this.reporter,
+					this.volume,
+					(data) => (this.casesData = data),
+				),
+			() =>
+				fetchReporterData(this.reporter, (data) => (this.reporterData = data)),
+			() =>
+				fetchVolumeData(
+					this.reporter,
+					this.volume,
+					(data) => (this.volumeData = data),
+				),
+		);
 	}
 
 	render() {

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -24,7 +24,7 @@ export const fetchVolumesData = async (reporter, callback) => {
 
 export const fetchVolumeData = async (reporter, volume, callback) => {
 	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/VolumeMetadata.json`;
-	callback(await fetchJson(url))
+	callback(await fetchJson(url));
 };
 
 export const fetchCasesList = async (reporter, volume, callback) => {

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -24,8 +24,7 @@ export const fetchVolumesData = async (reporter, callback) => {
 
 export const fetchVolumeData = async (reporter, volume, callback) => {
 	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/VolumeMetadata.json`;
-	const response = await fetch(url);
-	callback(await response.json());
+	callback(await fetchJson(url))
 };
 
 export const fetchCasesList = async (reporter, volume, callback) => {

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -59,6 +59,9 @@ export const fetchCaselawBody = async (
 ) => {
 	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/html/${caseName}.html`;
 	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error("Fetch failed.");
+	}
 	callback(await response.text());
 };
 
@@ -90,6 +93,9 @@ export const fetchMapData = async (callback) => {
 
 const fetchJson = async (url) => {
 	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error("Fetch failed.");
+	}
 	return await response.json();
 };
 

--- a/src/lib/fetchOr404.js
+++ b/src/lib/fetchOr404.js
@@ -1,0 +1,8 @@
+export async function fetchOr404 () {
+	const promises = [...arguments].map((arg) => arg.apply())
+	try {
+		await Promise.all(promises);
+	} catch {
+		window.location.replace(`./not-found/${location.search}`);
+	}
+};

--- a/src/lib/fetchOr404.js
+++ b/src/lib/fetchOr404.js
@@ -1,8 +1,8 @@
-export async function fetchOr404 () {
-	const promises = [...arguments].map((arg) => arg.apply())
+export async function fetchOr404() {
+	const promises = [...arguments].map((arg) => arg.apply());
 	try {
 		await Promise.all(promises);
 	} catch {
 		window.location.replace(`./not-found/${location.search}`);
 	}
-};
+}


### PR DESCRIPTION
See ENG-597.

Right now, if you navigate to a `/caselaw/?` URL that the [router routes](https://github.com/harvard-lil/capstone-static/blob/main/src/components/cap-content-router.js#L22-L49) to a data-fetching component... but there is no data to be fetched... we load a broken version of the page.

This PR redirects you to a 404 page instead by setting `window.location.href` to an actually 404ing URL, with the querystring preserved for transparency and clarity... and in case we want to do anything with that information in the future, like customizing the error message.

Example: `/caselaw?reporter=asdf` -> `/caselaw/not-found/?reporter=asdf`

It may be overbroad: I'm checking `response.ok`, and redirecting to 404 if false. We may prefer different error handling for other response codes, like 403 or 502... but I think this is probably close enough for jazz.

Let me know if `fetchOr404` is legible as is, or if it could benefit from some explanation 😄 