### PR TITLE
Rearranges footer components for a more balanced look

### DIFF
--- a/src/components/cap-footer.js
+++ b/src/components/cap-footer.js
@@ -104,8 +104,8 @@ export class CapFooter extends LitElement {
 					</a>
 				</div>
 
-				<ul class="footer__list">
-					${legalLinks.map(
+				<ul class="footer__list footer__navLinks">
+					${navLinks.map(
 						(link) =>
 							html`<li>
 								<a class="footer__textLink" href="${link.path}">${link.name}</a>
@@ -113,10 +113,10 @@ export class CapFooter extends LitElement {
 					)}
 				</ul>
 
-				<ul class="footer__list footer__navLinks">
-					${navLinks.map(
+				<ul class="footer__list">
+					${legalLinks.map(
 						(link) =>
-							html` <li>
+							html`<li>
 								<a class="footer__textLink" href="${link.path}">${link.name}</a>
 							</li>`,
 					)}


### PR DESCRIPTION
Now looks like this:

<img width="1503" alt="Screenshot 2024-02-06 at 9 11 42 AM" src="https://github.com/harvard-lil/capstone-static/assets/7401870/cd3a3f8a-ebd9-4830-8c78-619d0e4ff69c">

Rather than what's in this ticket:
https://linear.app/harvard-lil/issue/ENG-604/rearrange-links-in-footer