### PR TITLE
Slightly smoother rendering.

### DIFF
--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -82,7 +82,7 @@
 	<body>
 		<cap-nav></cap-nav>
 		<main id="main">
-			<cap-content-router></cap-content-router>
+			<cap-content-router class="c-tall"></cap-content-router>
 		</main>
 		<cap-footer></cap-footer>
 	</body>

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -6,6 +6,7 @@ import {
 	fetchCasesList,
 } from "../lib/data.js";
 
+import { isEmpty } from "../lib/isEmpty.js";
 import { fetchOr404 } from "../lib/fetchOr404.js";
 
 export default class CapCase extends LitElement {
@@ -517,39 +518,44 @@ export default class CapCase extends LitElement {
 	};
 
 	render() {
-		/*
-		This render method uses requestAnimationFrame to alter the links in
-		the shadow DOM once it's been rendered to change the logical links
-		to cited cases in the archived html to links to the presentation
-		layer version of the case.
-		*/
+		if (!isEmpty(this.caseBody) && !isEmpty(this.caseMetadata)) {
+			window.document.title = `${this.createCaseHeaderHeader(this.caseMetadata)} | Caselaw Access Project`;
 
-		// Skip the first frame which is the shadow DOM render
-		window.requestAnimationFrame(this.doNothing);
-		// Rewrite the links on the second frame
-		window.document.title = `${this.createCaseHeaderHeader(this.caseMetadata)} | Caselaw Access Project`;
-		window.requestAnimationFrame(this.rewriteLinks);
+			/*
+			This render method uses requestAnimationFrame to alter the links in
+			the shadow DOM once it's been rendered to change the logical links
+			to cited cases in the archived html to links to the presentation
+			layer version of the case.
+			*/
 
-		return html`
-			<div class="case-container">
-				<div class="case-header">
-					<h1>${this.createCaseHeaderHeader(this.caseMetadata)}</h1>
-					<div>
-						${this.getDecisionDate(this.caseMetadata.decision_date)}
-						<span class="court-name">${this.caseMetadata.court?.name}</span>
-						${this.getDocketNumber(this.caseMetadata.docket_number)}
+			// Skip the first frame which is the shadow DOM render
+			window.requestAnimationFrame(this.doNothing);
+			// Rewrite the links on the second frame
+			window.requestAnimationFrame(this.rewriteLinks);
+
+			return html`
+				<div class="case-container">
+					<div class="case-header">
+						<h1>${this.createCaseHeaderHeader(this.caseMetadata)}</h1>
+						<div>
+							${this.getDecisionDate(this.caseMetadata.decision_date)}
+							<span class="court-name">${this.caseMetadata.court?.name}</span>
+							${this.getDocketNumber(this.caseMetadata.docket_number)}
+						</div>
+						<div class="citations">
+							${this.createCitationsString(this.caseMetadata.citations)}
+						</div>
 					</div>
-					<div class="citations">
-						${this.createCitationsString(this.caseMetadata.citations)}
+					<div class="metadata">
+						<div class="case-name">${this.caseMetadata.name}</div>
 					</div>
+					<!--section.casebody -->
+					${unsafeHTML(this.caseBody)}
 				</div>
-				<div class="metadata">
-					<div class="case-name">${this.caseMetadata.name}</div>
-				</div>
-				<!--section.casebody -->
-				${unsafeHTML(this.caseBody)}
-			</div>
-		`;
+			`;
+		} else {
+			return nothing;
+		}
 	}
 }
 

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -1,4 +1,5 @@
-import { LitElement, html, css } from "../lib/lit.js";
+import { LitElement, html, css, nothing } from "../lib/lit.js";
+import { isEmpty } from "../lib/isEmpty.js";
 import { fetchJurisdictionsData } from "../lib/data.js";
 import { baseStyles } from "../lib/wc-base.js";
 import { slugify } from "../lib/slugify.js";
@@ -151,48 +152,52 @@ export default class CapJurisdictions extends LitElement {
 	}
 
 	render() {
-		return html`
-			<cap-caselaw-layout>
-				<header class="jurisdictions__header">
-					<cap-page-header heading="Read Caselaw" theme="light" icon="none">
-						<p class="jurisdictions__description">
-							Browse all volumes of the Caselaw Access Project below.
-						</p>
-					</cap-page-header>
-				</header>
-				<aside class="u-w-fit u-sm-hidden">
-					<cap-anchor-list
-						.data=${this.getJurisdictionNameLinks()}
-					></cap-anchor-list>
-				</aside>
-				<div class="jurisdictions__main">
-					${Object.keys(this.jurisdictionsData)
-						.sort()
-						.map(
-							(jurisdiction) =>
-								html`<article
-									class="jurisdiction"
-									id="${slugify(jurisdiction)}"
-								>
-									<h2 class="jurisdiction__heading">${jurisdiction}</h2>
-									<ul class="jurisdiction__reporterList">
-										${this.jurisdictionsData[jurisdiction].map(
-											(reporter) =>
-												html`<li>
-													<a
-														class="jurisdiction__link"
-														href="/caselaw/?reporter=${reporter.slug}"
-														>${reporter.short_name}</a
-													>: ${reporter.full_name}
-													(${reporter.start_year}-${reporter.end_year})
-												</li>`,
-										)}
-									</ul>
-								</article>`,
-						)}
-				</div>
-			</cap-caselaw-layout>
-		`;
+		if (!isEmpty(this.jurisdictionsData)) {
+			return html`
+				<cap-caselaw-layout>
+					<header class="jurisdictions__header">
+						<cap-page-header heading="Read Caselaw" theme="light" icon="none">
+							<p class="jurisdictions__description">
+								Browse all volumes of the Caselaw Access Project below.
+							</p>
+						</cap-page-header>
+					</header>
+					<aside class="u-w-fit u-sm-hidden">
+						<cap-anchor-list
+							.data=${this.getJurisdictionNameLinks()}
+						></cap-anchor-list>
+					</aside>
+					<div class="jurisdictions__main">
+						${Object.keys(this.jurisdictionsData)
+							.sort()
+							.map(
+								(jurisdiction) =>
+									html`<article
+										class="jurisdiction"
+										id="${slugify(jurisdiction)}"
+									>
+										<h2 class="jurisdiction__heading">${jurisdiction}</h2>
+										<ul class="jurisdiction__reporterList">
+											${this.jurisdictionsData[jurisdiction].map(
+												(reporter) =>
+													html`<li>
+														<a
+															class="jurisdiction__link"
+															href="/caselaw/?reporter=${reporter.slug}"
+															>${reporter.short_name}</a
+														>: ${reporter.full_name}
+														(${reporter.start_year}-${reporter.end_year})
+													</li>`,
+											)}
+										</ul>
+									</article>`,
+							)}
+					</div>
+				</cap-caselaw-layout>
+			`;
+		} else {
+			return nothing;
+		}
 	}
 }
 

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -1,9 +1,10 @@
-import { LitElement, html, css } from "../lib/lit.js";
+import { LitElement, html, css, nothing } from "../lib/lit.js";
 import {
 	fetchVolumesData,
 	fetchReporterData,
 	getBreadcrumbLinks,
 } from "../lib/data.js";
+import { isEmpty } from "../lib/isEmpty.js";
 import { fetchOr404 } from "../lib/fetchOr404.js";
 import { baseStyles } from "../lib/wc-base.js";
 import "./cap-breadcrumb.js";
@@ -100,39 +101,43 @@ export default class CapReporter extends LitElement {
 	}
 
 	render() {
-		window.document.title = `Reporter: ${this.reporterData.short_name} | Caselaw Access Project`;
-		return html`
-			<cap-caselaw-layout>
-				<div class="reporter">
-					<cap-breadcrumb
-						.navItems=${getBreadcrumbLinks(this.reporterData)}
-					></cap-breadcrumb>
-					<hgroup class="reporter__headingGroup">
-						<h1 class="reporter__heading">${this.reporterData.short_name}</h1>
-						<p class="reporter__subHeading">
-							${this.reporterData.full_name}
-							(${this.reporterData.start_year}-${this.reporterData.end_year}).
-						</p>
-					</hgroup>
-					<ul class="reporter__volumeList">
-						<p class="reporter__volumeTitle">Volume number:</p>
-						${this.volumesData
-							.sort((a, b) => a.volume_number - b.volume_number)
-							.map(
-								(v) =>
-									html`<li>
-										<a
-											href="/caselaw/?reporter=${this
-												.reporter}&volume=${v.volume_number}"
-											>${v.volume_number}</a
-										>
-									</li>`,
-							)}
-					</ul>
-				</div>
-				<cap-caselaw-layout> </cap-caselaw-layout
-			></cap-caselaw-layout>
-		`;
+		if (!isEmpty(this.volumesData) && !isEmpty(this.reporterData)) {
+			window.document.title = `Reporter: ${this.reporterData.short_name} | Caselaw Access Project`;
+			return html`
+				<cap-caselaw-layout>
+					<div class="reporter">
+						<cap-breadcrumb
+							.navItems=${getBreadcrumbLinks(this.reporterData)}
+						></cap-breadcrumb>
+						<hgroup class="reporter__headingGroup">
+							<h1 class="reporter__heading">${this.reporterData.short_name}</h1>
+							<p class="reporter__subHeading">
+								${this.reporterData.full_name}
+								(${this.reporterData.start_year}-${this.reporterData.end_year}).
+							</p>
+						</hgroup>
+						<ul class="reporter__volumeList">
+							<p class="reporter__volumeTitle">Volume number:</p>
+							${this.volumesData
+								.sort((a, b) => a.volume_number - b.volume_number)
+								.map(
+									(v) =>
+										html`<li>
+											<a
+												href="/caselaw/?reporter=${this
+													.reporter}&volume=${v.volume_number}"
+												>${v.volume_number}</a
+											>
+										</li>`,
+								)}
+						</ul>
+					</div>
+					<cap-caselaw-layout> </cap-caselaw-layout
+				></cap-caselaw-layout>
+			`;
+		} else {
+			return nothing;
+		}
 	}
 }
 

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -1,10 +1,11 @@
-import { LitElement, html, css } from "../lib/lit.js";
+import { LitElement, html, css, nothing } from "../lib/lit.js";
 import {
 	fetchCasesList,
 	fetchReporterData,
 	fetchVolumeData,
 	getBreadcrumbLinks,
 } from "../lib/data.js";
+import { isEmpty } from "../lib/isEmpty.js";
 import { fetchOr404 } from "../lib/fetchOr404.js";
 import { baseStyles } from "../lib/wc-base.js";
 import "./cap-breadcrumb.js";
@@ -110,44 +111,52 @@ export default class CapVolume extends LitElement {
 	}
 
 	render() {
-		window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
-		return html`
-			<cap-caselaw-layout>
-				<div class="volume">
-					<cap-breadcrumb
-						.navItems=${getBreadcrumbLinks(this.reporterData, this.volume)}
-					></cap-breadcrumb>
-					<hgroup class="volume__headingGroup">
-						<h1 class="volume__heading">
-							${this.volume} ${this.reporterData.short_name}
-						</h1>
-						<p class="volume__subHeading">
-							${this.reporterData.full_name}
-							(${this.reporterData.start_year}-${this.reporterData.end_year})
-							volume ${this.volume}.
-						</p>
-					</hgroup>
-					<ul class="volume__caseList">
-						${this.casesData.map(
-							(c) =>
-								html`<li>
-									<a
-										href="/caselaw/?reporter=${this.reporter}&volume=${this
-											.volume}&case=${String(c.first_page).padStart(
-											4,
-											"0",
-										)}-${String(c.ordinal).padStart(2, "0")}"
-									>
-										${c.name_abbreviation},
-										${c.citations.filter((c) => c.type == "official")[0].cite}
-										(${c.decision_date.substring(0, 4)})
-									</a>
-								</li>`,
-						)}
-					</ul>
-				</div>
-			</cap-caselaw-layout>
-		`;
+		if (
+			!isEmpty(this.casesData) &&
+			!isEmpty(this.reporterData) &&
+			!isEmpty(this.volumeData)
+		) {
+			window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
+			return html`
+				<cap-caselaw-layout>
+					<div class="volume">
+						<cap-breadcrumb
+							.navItems=${getBreadcrumbLinks(this.reporterData, this.volume)}
+						></cap-breadcrumb>
+						<hgroup class="volume__headingGroup">
+							<h1 class="volume__heading">
+								${this.volume} ${this.reporterData.short_name}
+							</h1>
+							<p class="volume__subHeading">
+								${this.reporterData.full_name}
+								(${this.reporterData.start_year}-${this.reporterData.end_year})
+								volume ${this.volume}.
+							</p>
+						</hgroup>
+						<ul class="volume__caseList">
+							${this.casesData.map(
+								(c) =>
+									html`<li>
+										<a
+											href="/caselaw/?reporter=${this.reporter}&volume=${this
+												.volume}&case=${String(c.first_page).padStart(
+												4,
+												"0",
+											)}-${String(c.ordinal).padStart(2, "0")}"
+										>
+											${c.name_abbreviation},
+											${c.citations.filter((c) => c.type == "official")[0].cite}
+											(${c.decision_date.substring(0, 4)})
+										</a>
+									</li>`,
+							)}
+						</ul>
+					</div>
+				</cap-caselaw-layout>
+			`;
+		} else {
+			return nothing;
+		}
 	}
 }
 

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -47,3 +47,8 @@
 .c-article h2 + * {
 	margin-block-start: var(--spacing-100);
 }
+
+.c-tall {
+	display: block;
+	min-height: 100vh;
+}

--- a/src/lib/isEmpty.js
+++ b/src/lib/isEmpty.js
@@ -1,0 +1,13 @@
+export const isEmpty = (obj) => {
+	if (obj === null || obj === undefined) {
+		return True;
+	} else if (Array.isArray(obj) || typeof obj === "string") {
+		return obj.length === 0;
+	} else if (
+		["boolean", "number", "bigint", "symbol", "function"].includes(typeof obj)
+	) {
+		throw new Error(f`Unsuported type: ${typeof obj}`);
+	} else {
+		return Object.keys(obj).length === 0;
+	}
+};


### PR DESCRIPTION
This is a very tiny PR, despite the large diff. It makes only two changes:

- It adds an `if` to the pages at /caselaw/ so that they don't try to render HTML that assumes the presence of data until that data is present, rendering `nothing` instead. 

- Since we know that all the pages at /caselaw/ are going to be taller than the viewport height, once the data loads, it sets a min-height for the data-dependent HTML that pushes the footer below the fold from the get-go, for a smoother experience. 

It does NOT fix a major rendering weirdness of the 404 page: the contents of the `slot`, which are in the light DOM, are visible in a 100% unstyled way for an instant before the page snaps into place. Weird. I couldn't think of any solution 🤷‍♀️ 

I think this materially helps; TBD if there's any more to do 🙂 