### PR TITLE
feat: Add missing css class to wc-base file

### DIFF
--- a/src/lib/wc-base.js
+++ b/src/lib/wc-base.js
@@ -89,4 +89,10 @@ export const baseStyles = css`
 	.u-w-maxContent {
 		max-width: 41rem;
 	}
+
+	.u-sm-hidden {
+		@media (max-width: 60rem) {
+			display: none;
+		}
+	}
 `;


### PR DESCRIPTION
## Summary 
This fixes an issue where the sidebar on the caselaw by jurisdiction page was not hidden for mobile views: 

![Screenshot 2024-02-05 at 9 49 48 AM](https://github.com/harvard-lil/capstone-static/assets/4039311/5c8ccfaf-ecf2-48f2-8242-672813ebc71e)

It turns out the issue was that we were missing a CSS class from `wc-base.js`. All reusable css classes that we want to apply internally to a scoped web component need to be defined there, in addition to where they are defined elsewhere. 

## Notes 
Needing to duplicate utility classes in two different places is a tedious process that is easily error-prone. I think in the future, if we ever need different versions of the same utility class (a version for web components, in JavaScript, and a version in vanilla CSS, for example) we can solve issues with consistency by using [Cobalt.](https://cobalt-ui.pages.dev/), which can take one JSON file of design tokens and output multiple formats. 

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run git pull tinykite to make sure you have the latest remote branches
- Run git checkout add-missing-class to checkout this branch