### PR TITLE
feat: Update link styles for consistency

### DIFF
--- a/src/components/cap-media-list.js
+++ b/src/components/cap-media-list.js
@@ -54,6 +54,15 @@ export class CapMediaList extends LitElement {
 				}
 			}
 
+			.mediaList__link--light {
+				text-decoration: none;
+
+				&:hover {
+					--color-link-hover: var(--color-blue-500);
+					text-decoration: underline;
+				}
+			}
+
 			.mediaList__date {
 				color: var(--color-date);
 			}
@@ -91,7 +100,14 @@ export class CapMediaList extends LitElement {
 								"mediaList__item--bulleted": this.decoration === "bulleted",
 							})}
 						>
-							<a class="mediaList__link" href="${link.url}">${link.title}</a>
+							<a
+								class=${clsx(
+									"mediaList__link",
+									`mediaList__link--${this.theme}`,
+								)}
+								href="${link.url}"
+								>${link.title}</a
+							>
 							<span class="mediaList__publisher">${link.publisher}</span>
 							<span class="mediaList__date">${link.date}</span>
 						</li>


### PR DESCRIPTION
## What this does 
I noticed that the about page unintentionally featured two separate link styles. Most links were blue, with a darker shade of blue and a text underline applied on hover. But the links rendered by the `cap-media-list` component, which can render two separate color schemes for light and dark themed sections of the website, were slightly different. 

On hover, they display a dark gray link with no underline.

![Screenshot 2024-02-07 at 2 34 45 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/b3eed0f7-366d-4cb9-b406-837309164555)

This fixes that discrepancy with an update to the light theme link styles in `cap-media-list`. 

## Screenshot
![Screenshot 2024-02-07 at 2 30 54 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/3ba86fc3-e013-4895-8d5a-8f92530f6dc2)

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run git pull tinykite to make sure you have the latest remote branches
- Run git checkout finesse-link-state to checkout this branch