### PR TITLE
feat: Add missing press links for about page

### DIFF
--- a/src/components/cap-media-list.js
+++ b/src/components/cap-media-list.js
@@ -1,12 +1,12 @@
 import { LitElement, html, css } from "../lib/lit.js";
 import { baseStyles } from "../lib/wc-base.js";
-import { pressLinks } from "../data/pressLinks.js";
 import clsx from "../lib/clsx.js";
 
 export class CapMediaList extends LitElement {
 	static properties = {
 		decoration: { type: String | undefined },
 		theme: { type: String | undefined },
+		data: { type: Array },
 	};
 
 	static styles = [
@@ -80,11 +80,12 @@ export class CapMediaList extends LitElement {
 		super();
 		this.theme = "light";
 		this.decoration = "bulleted";
+		this.data = [];
 	}
 	render() {
 		return html`
 			<ul class=${clsx("mediaList", `mediaList--${this.theme}`)}>
-				${pressLinks.map((link) => {
+				${this.data.map((link) => {
 					return html`
 						<li
 							class=${clsx("mediaList__item", {

--- a/src/components/cap-section-highlight.js
+++ b/src/components/cap-section-highlight.js
@@ -116,7 +116,7 @@ export class CapSectionHighlight extends LitElement {
 					<cap-media-list
 						theme="dark"
 						decoration="none"
-						.data=${pressLinks}
+						.data=${pressLinks.slice(0, 5)}
 					></cap-media-list>
 				</div>
 

--- a/src/data/pressLinks.js
+++ b/src/data/pressLinks.js
@@ -46,7 +46,7 @@ export const pressLinks = [
 	},
 	{
 		title: "Harvard Law Library Readies Trove of Decisions for Digital Age",
-		publisher: "The New York Times ",
+		publisher: "The New York Times",
 		date: "October 28, 2015",
 		url: "http://www.nytimes.com/2015/10/29/us/harvard-law-library-sacrifices-a-trove-for-the-sake-of-a-free-database.html",
 	},

--- a/src/data/pressLinks.js
+++ b/src/data/pressLinks.js
@@ -31,4 +31,23 @@ export const pressLinks = [
 		date: "October 31, 2018",
 		url: "https://www.techdirt.com/2018/10/31/harvard-opens-up-massive-caselaw-access-project/",
 	},
+	{
+		title: "Caselaw Access Project launches API and bulk data service",
+		publisher: "Harvard Law Today",
+		date: "October 31, 2018",
+		url: "https://today.law.harvard.edu/caselaw-access-project-launches-api-and-bulk-data-service/",
+	},
+	{
+		title:
+			"Caselaw Access Project gives free access to 360 years of American court cases",
+		publisher: "ABA Journal",
+		date: "October 30, 2018",
+		url: "http://www.abajournal.com/news/article/caselaw_access_project_gives_free_access_to_360_years_of_american_court_cas",
+	},
+	{
+		title: "Harvard Law Library Readies Trove of Decisions for Digital Age",
+		publisher: "The New York Times ",
+		date: "October 28, 2015",
+		url: "http://www.nytimes.com/2015/10/29/us/harvard-law-library-sacrifices-a-trove-for-the-sake-of-a-free-database.html",
+	},
 ];

--- a/src/templates/cap-about-page.js
+++ b/src/templates/cap-about-page.js
@@ -4,6 +4,7 @@ import "../components/cap-page-header.js";
 import "../components/cap-footer.js";
 import "../components/cap-anchor-list.js";
 import "../components/cap-media-list.js";
+import { pressLinks } from "../data/pressLinks.js";
 import "../components/cap-contributor-list.js";
 import { anchorLinks } from "../data/aboutSidebarLinks.js";
 
@@ -189,7 +190,7 @@ export class CapAboutPage extends LitElement {
 						</strong>
 					</p>
 					<h2 class="c-decoratedHeader" id="press">Press</h2>
-					<cap-media-list></cap-media-list>
+					<cap-media-list .data=${pressLinks}></cap-media-list>
 
 					<h2 class="c-decoratedHeader" id="friends-and-partners">
 						Friends and Partners


### PR DESCRIPTION
## What This Does
Adds 3 missing press links that appear on the current CAP website's about page — in the press section — but were missing from the cap static version. Because we only want to surface a subset of this full list of links, this also modifies the homepage and the `cap-media-list` component to make it possible to customize what media links the component displays on a case-by-case basis. 

## Screenshots
The homepage will continue to display only 5 links: 
![Screenshot 2024-02-08 at 1 25 34 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/754d4baa-77b2-45f1-904e-a6bf783642b3)

The press section of the about page will display the full press archive of links:
![Screenshot 2024-02-08 at 1 25 47 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/2f02401e-2092-4b05-a246-59a0417c410f)


## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout add-missing-press-links` to checkout this branch