### PR TITLE
Fix citation links. Add page-level disambiguation.

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -445,7 +445,7 @@ export default class CapCase extends LitElement {
 			}
 
 			// links that have multiple possible cases need to go to a disambiguation page
-			// http://localhost:5501/caselaw/?disambiguate=%2Fus%2F351%2F0967-03%2C%2Fus%2F351%2F0967-07%2C%2Fus%2F351%2F0967-04%2C%2Fus%2F351%2F0967-02%2C%2Fus%2F351%2F0967-06%2C%2Fus%2F351%2F0967-01%2C%2Fus%2F351%2F0967-05&cite=351%20U.S.%20967
+			// http://localhost:5501/caselaw/?disambiguate=%2Fill-app%2F302%2F0570-02%2C%2Fill-app%2F302%2F0570-01&cite=302%20Ill%20App%20570
 			if (casePath.includes(",")) {
 				const newUrl = new URL(
 					`/caselaw/?disambiguate=${encodeURIComponent(casePath)}&cite=${encodeURIComponent(a.innerText)}`,

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -430,90 +430,45 @@ export default class CapCase extends LitElement {
 	rewriteLinks = () => {
 		this.shadowRoot.querySelectorAll("a").forEach((a) => {
 			const oldLink = a.getAttribute("href");
+			const linkType = a.getAttribute("class");
+			const casePath = a.getAttribute("data-case-paths");
+
 			// skip links without hrefs or that point back at the same page
-			if (!oldLink || oldLink.startsWith("#")) {
+			if (!oldLink || oldLink.startsWith("#") || !(linkType === "citation")) {
 				return;
 			}
-			const oldUrl = new URL(oldLink);
-			if (oldUrl.hostname === "cite.case.law") {
-				const pathComponents = oldUrl.pathname
+
+			// links without casePath are to a search page we will no longer support.
+			if (!casePath) {
+				this.removeLink(a);
+				return;
+			}
+
+			// links that have multiple possible cases need to go to a disambiguation page
+			// http://localhost:5501/caselaw/?disambiguate=%2Fus%2F351%2F0967-03%2C%2Fus%2F351%2F0967-07%2C%2Fus%2F351%2F0967-04%2C%2Fus%2F351%2F0967-02%2C%2Fus%2F351%2F0967-06%2C%2Fus%2F351%2F0967-01%2C%2Fus%2F351%2F0967-05&cite=351%20U.S.%20967
+			if (casePath.includes(",")) {
+				const newUrl = new URL(
+					`/caselaw/?disambiguate=${encodeURIComponent(casePath)}&cite=${encodeURIComponent(a.innerText)}`,
+					window.location,
+				);
+				a.setAttribute("href", newUrl);
+				return;
+			} else {
+				// a normal link to a single case
+				const pathComponents = casePath
 					.split("/")
 					// remove empty strings. Deals with paths that start
 					// or end with / and double slashes
 					.filter((x) => x !== "");
-				if (pathComponents.length === 3) {
-					/*
-					Case: /reporter/volume/page
-					E.g.: https://cite.case.law/ill-app-3d/16/850/
-					This represents a citation to a particular page
-					where only one case starts.
-					*/
-					const [reporter, volume, page] = pathComponents;
-					//http://localhost:5501/caselaw/?reporter=ark-app&volume=12&case=0028
-					const newUrl = new URL(
-						`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-01`,
-						window.location,
-					);
-					a.setAttribute("href", newUrl);
-					return;
-				} else if (pathComponents.length === 4) {
-					/*
-					Case: /reporter/volume/page/caseId
-					E.g.: https://cite.case.law/mass/400/1006/880059/
-					This represents a citation to a particular page
-					where more than one case begins, so an
-					additional disambiguating suffix is added to
-					the URL. We need to translate that to the ordinal
-					number of the case on the page.
-					*/
-					const [reporter, volume, page, caseId] = pathComponents;
 
-					// First we need to load CasesMetadata for the cited case
-					new Promise((resolve, reject) => {
-						fetchCasesList(reporter, volume, (data) => {
-							try {
-								resolve(data);
-							} catch (e) {
-								reject(e);
-							}
-						});
-					}).then(
-						(casesList) => {
-							// Find the one with the correct case id
-							const citedCase = casesList.find(
-								(x) => x.id.toString() === caseId,
-							);
-
-							// construct the proper link to the case
-							const newUrl = new URL(
-								`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-${citedCase.ordinal.toString().padStart(2, "0")}`,
-								window.location,
-							);
-
-							///set the href of the link to the new url
-							a.setAttribute("href", newUrl);
-						},
-						(error) => {
-							// Got an error looking up the CasesMetadata. Remove the link because we can't resolve it
-							this.removeLink(a);
-							return;
-						},
-					);
-					return;
-				} else if (oldUrl.searchParams.has("q")) {
-					/*
-					Case: https://cite.case.law/citations/?q=42%20U.S.C.%20%C2%A7%201983
-					This represents a link to a statute we
-					don't actually have the copy for, so
-					instead, we do a search on other cases
-					that cite the same statute. We'll remove
-					this.
-					*/
-					this.removeLink(a);
-					return;
-				}
+				const [reporter, volume, page] = pathComponents;
+				const newUrl = new URL(
+					`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-01`,
+					window.location,
+				);
+				a.setAttribute("href", newUrl);
+				return;
 			}
-			// If we're here, we don't know what this url is, so leave it be.
 		});
 	};
 

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -4,6 +4,7 @@ import "./cap-volume.js";
 import "./cap-case.js";
 import "./cap-jurisdictions.js";
 import "./cap-reporter.js";
+import "./cap-disambiguate.js";
 
 export default class CapContentRouter extends LitElement {
 	static styles = [
@@ -24,6 +25,15 @@ export default class CapContentRouter extends LitElement {
 		const reporter = searchParams.get("reporter");
 		const volume = searchParams.get("volume");
 		const caseName = searchParams.get("case");
+		const disambiguate = searchParams.get("disambiguate");
+		const cite = searchParams.get("cite");
+
+		if (!!disambiguate) {
+			return html`<cap-disambiguate
+				list="${disambiguate},"
+				cite=${cite}
+			></cap-disambiguate>`;
+		}
 
 		if (!!caseName && !!volume && !!reporter) {
 			return html`<cap-case

--- a/src/components/cap-disambiguate.js
+++ b/src/components/cap-disambiguate.js
@@ -1,0 +1,199 @@
+import { LitElement, html, css, nothing } from "../lib/lit.js";
+import { baseStyles } from "../lib/wc-base.js";
+import {
+	fetchCasesList,
+	fetchReporterData,
+	fetchVolumeData,
+	getBreadcrumbLinks,
+} from "../lib/data.js";
+
+import { isEmpty } from "../lib/isEmpty.js";
+import { fetchOr404 } from "../lib/fetchOr404.js";
+
+// The point of this component is to disambiguate between multiple
+// cases when a page has been cited, but multiple cases start on that page.
+// Links to this compoent are first created in the static html export, and then
+// fixed up in cap-case.js.
+
+export default class CapDisambiguate extends LitElement {
+	static properties = {
+		list: { type: String },
+		cite: { type: String },
+		casesData: { attribute: false, type: Array },
+		volumeData: { attribute: false, type: Object },
+		reporterData: { attribute: false, type: Object },
+		reporter: { attribute: false, type: String },
+		volume: { attribute: false, type: String },
+	};
+
+	constructor() {
+		super();
+		this.casesData = [];
+		this.caseStrings = [];
+		this.volumeData = {};
+		this.reporterData = {};
+		this.reporter = "";
+		this.volume = "";
+	}
+
+	async connectedCallback() {
+		super.connectedCallback();
+
+		// This is a hack based on the assumption that all the links have the same reporter and volume.
+		// Jack thinks this is a reasonable assumption, but it's worth noting that it's not guaranteed by the arguments.
+
+		this.caseStrings = Array.from(
+			this.list.split(",").filter((s) => s.length > 0),
+		);
+
+		const firstCaseString = this.caseStrings[0]; // first case in the list
+
+		// convert that to reporter / volume / page, but we don't need the page
+		const [reporter, volume, page] = Array.from(
+			firstCaseString.split("/").filter((s) => s.length > 0),
+		);
+
+		this.reporter = reporter;
+		this.volume = volume;
+
+		fetchOr404(
+			fetchReporterData(reporter, (data) => {
+				this.reporterData = data;
+			}),
+			fetchVolumeData(reporter, volume, (data) => {
+				this.volumeData = data;
+			}),
+			fetchCasesList(reporter, volume, (data) => {
+				this.casesData = data;
+			}),
+		);
+	}
+
+	static styles = [
+		baseStyles,
+
+		css`
+			p,
+			ul {
+				font-family: var(--font-sans-text);
+
+				@media (min-width: 35rem) {
+					font-size: var(--font-size-175);
+				}
+			}
+
+			ul {
+				padding: 0;
+			}
+
+			li {
+				list-style-type: none;
+			}
+
+			a:link,
+			a:visited,
+			a:hover,
+			a:active {
+				text-decoration: none;
+				color: var(--color-blue-400);
+			}
+
+			a:hover {
+				color: var(--color-blue-500);
+				text-decoration: underline;
+			}
+
+			.disambiguate {
+				grid-column: 1 / -1;
+				padding-inline: var(--spacing-500);
+				padding-block-start: var(--spacing-400);
+				padding-block-end: var(--spacing-550);
+			}
+
+			.disambiguate__headingGroup {
+				margin-block-start: var(--spacing-100);
+			}
+
+			.disambiguate__heading {
+				font-weight: 600;
+				font-size: var(--font-size-250);
+				position: relative;
+			}
+
+			.disambiguate__subHeading {
+				font-size: var(--font-size-175);
+				margin-block-start: var(--spacing-0);
+				font-weight: 500;
+			}
+
+			.disambiguate__caseList {
+				margin-block-start: var(--spacing-150);
+				display: block;
+			}
+		`,
+	];
+
+	render() {
+		if (!isEmpty(this.casesData)) {
+			const cases = [];
+
+			for (const caseString of this.caseStrings) {
+				const [reporter, volume, pageAndOrdinal] = Array.from(
+					caseString.split("/").filter((s) => s.length > 0),
+				);
+
+				const [page, ordinal] = pageAndOrdinal.split("-");
+				const caseData = this.casesData.find((c) => {
+					return (
+						c.ordinal === parseInt(ordinal) &&
+						c.first_page === parseInt(page).toString()
+					);
+				});
+				cases.push(caseData);
+			}
+
+			const breadcrumbLinks = getBreadcrumbLinks(
+				this.reporterData,
+				this.volume,
+			);
+			breadcrumbLinks.push({
+				name: `Page ${cases[0].first_page} disambiguation`,
+				url: window.location.href,
+			});
+
+			window.document.title = `Volume: ${this.reporterData.short_name} volume ${this.volume} | Caselaw Access Project`;
+			return html`
+				<cap-caselaw-layout>
+					<div class="disambiguate">
+						<cap-breadcrumb .navItems=${breadcrumbLinks}></cap-breadcrumb>
+						<hgroup class="disambiguate__headingGroup">
+							<h1 class="disambiguate__heading">${this.cite}</h1>
+							<p class="disambiguate__subHeading">Multiple cases match:</p>
+						</hgroup>
+						<ul class="disambiguate__caseList">
+							${cases.map(
+								(c) =>
+									html`<li>
+										<a
+											href="/caselaw/?reporter=${this.reporter}&volume=${this
+												.volume}&case=${String(c.first_page).padStart(
+												4,
+												"0",
+											)}-${String(c.ordinal).padStart(2, "0")}"
+										>
+											${c.name_abbreviation},
+											${c.citations.filter((c) => c.type == "official")[0].cite}
+											(${c.decision_date.substring(0, 4)})
+										</a>
+									</li>`,
+							)}
+						</ul>
+					</div>
+				</cap-caselaw-layout>
+			`;
+		} else {
+			return nothing;
+		}
+	}
+}
+customElements.define("cap-disambiguate", CapDisambiguate);


### PR DESCRIPTION
This PR addresses changes with link rewriting to reflect the cap export changes that rendered much of what was previously done obsolete, and also handles a new edge case I learned about last week.

Previously, the HTML export was writing citation links that pointed at cite.case.law explicitly. Now, the export points at path-based links in the static export, and does not include a hostname. 

Additionally, the work of resolving a link to a specific ordinal on the page is now handled by the export, so my code is no longer needed.

However, there are instances where a link is ambiguous, in that it doesn't specify which case on a given page it's linking to, so we need to render a disambiguation page. In the live app, those look like this: https://cite.case.law/ill-app/302/570/

Multiple cases appear on page 570 of that volume, so we need to show a list of them.

My new code takes information in data attributes of the referring link and uses them to load metadata about that page and render the links. I am working under the assumption that these links will always address the same page of the volume, and using that to make decisions about reporter, volume and page metadata.

To test this PR, navigate to `/caselaw/?reporter=ill-app-2d&volume=45&case=0044-01` and navigate to the link to `302 Ill App 570`. You should end up on a page with links to two cases on it:

* Woods v. Lawndale Enterprises, Inc., 302 Ill. App. 570 (1939)
* Wade v. Keith, 302 Ill. App. 570 (1939)

Those links should link to those cases.