### PR TITLE
Update docs metadata

### DIFF
--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -1,19 +1,73 @@
 <!doctype html>
 <html lang="en">
-	<head>
+	<head
+		prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#"
+	>
 		<title>Documentation | Caselaw Access Project</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="noindex" />
-		<meta name="author" content="Your name" />
-		<meta name="description" content="Explore American Caselaw" />
+
 		<meta property="og:title" content="Caselaw Access Project" />
+		<meta property="twitter:title" content="Caselaw Access Project" />
+		<meta name="description" content="Explore American Caselaw" />
 		<meta property="og:description" content="Explore American Caselaw" />
+		<meta name="twitter:description" content="Explore American Caselaw" />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta
+			name="twitter:image"
+			content="https://case.law/images/og_image/index.png"
+		/>
+		<meta
+			property="og:image"
+			content="https://case.law/images/og_image/index.png"
+		/>
+		<meta name="twitter:site" content="@caselawaccess" />
+		<meta name="twitter:creator" content="@HarvardLIL" />
 		<meta property="og:url" content="https://case.law/" />
 		<meta property="og:type" content="article" />
-		<meta property="og:site_name" content="Caselaw Access Projects" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<link
+			rel="apple-touch-icon"
+			sizes="152x152"
+			href="images/favicon/apple-touch-icon.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="192x192"
+			href="images/favicon/android-chrome-144x144.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="96x96"
+			href="images/favicon/favicon.ico"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="32x32"
+			href="images/favicon/favicon-32x32.png"
+		/>
+		<link
+			rel="icon"
+			type="image/png"
+			sizes="16x16"
+			href="images/favicon/favicon-16x16.png"
+		/>
+		<link
+			rel="mask-icon"
+			href="images/favicon/safari-pinned-tab.svg"
+			color="#0075FF"
+		/>
+		<meta name="msapplication-TileColor" content="#2b5797" />
+		<meta
+			name="msapplication-TileImage"
+			content="images/favicon/mstile-150x150.png"
+		/>
+		<meta name="theme-color" content="#ffffff" />
 		<script type="module" src="/templates/cap-docs-page.js"></script>
 	</head>
 	<body>

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -28,11 +28,11 @@
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta
 			name="twitter:image"
-			content="https://case.law/images/og_image/index.png"
+			content="https://case.law/static/img/og_image/documentation.png"
 		/>
 		<meta
 			property="og:image"
-			content="https://case.law/images/og_image/index.png"
+			content="https://case.law/static/img/og_image/documentation.png"
 		/>
 		<meta name="twitter:site" content="@caselawaccess" />
 		<meta name="twitter:creator" content="@HarvardLIL" />

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -8,11 +8,23 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="robots" content="noindex" />
 
-		<meta property="og:title" content="Caselaw Access Project" />
-		<meta property="twitter:title" content="Caselaw Access Project" />
-		<meta name="description" content="Explore American Caselaw" />
-		<meta property="og:description" content="Explore American Caselaw" />
-		<meta name="twitter:description" content="Explore American Caselaw" />
+		<meta
+			property="og:title"
+			content="Documentation | Caselaw Access Project"
+		/>
+		<meta
+			property="twitter:title"
+			content="Documentation | Caselaw Access Project"
+		/>
+		<meta name="description" content="Caselaw Access Project Documentation" />
+		<meta
+			property="og:description"
+			content="Caselaw Access Project Documentation"
+		/>
+		<meta
+			name="twitter:description"
+			content="Caselaw Access Project Documentation"
+		/>
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta
 			name="twitter:image"
@@ -24,7 +36,7 @@
 		/>
 		<meta name="twitter:site" content="@caselawaccess" />
 		<meta name="twitter:creator" content="@HarvardLIL" />
-		<meta property="og:url" content="https://case.law/" />
+		<meta property="og:url" content="https://case.law/docs/" />
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -28,11 +28,11 @@
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta
 			name="twitter:image"
-			content="https://case.law/static/img/og_image/documentation.png"
+			content="https://case.law/images/og_image/documentation.png"
 		/>
 		<meta
 			property="og:image"
-			content="https://case.law/static/img/og_image/documentation.png"
+			content="https://case.law/images/og_image/documentation.png"
 		/>
 		<meta name="twitter:site" content="@caselawaccess" />
 		<meta name="twitter:creator" content="@HarvardLIL" />


### PR DESCRIPTION
## What this does
This copies metadata to the docs page to better match other CAP static webpages, so that all pages have as in-depth metadata as possible. 

## Notes
- I haven't updated the screenshot of the documentation page, that's included as an open graph preview image, in case we end up updating the documentation copy. 

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout update-docs-metadata` to checkout this branch