### PR TITLE
feat: Update contributors

### DIFF
--- a/src/data/contributors.js
+++ b/src/data/contributors.js
@@ -1,5 +1,15 @@
 export const contributorLinks = [
 	{
+		name: "Ebru Yucesar",
+		job_title: "Senior Software Engineer",
+		url: "https://lil.law.harvard.edu/about/#ebru-yucesar",
+	},
+	{
+		name: "Rebecca Cremona",
+		job_title: "Senior Software Engineer",
+		url: "https://lil.law.harvard.edu/about/#rebecca-cremona",
+	},
+	{
 		name: "Dakota Sexton",
 		job_title: "Senior Software Engineer",
 		url: "https://www.tinykitelab.com",


### PR DESCRIPTION
## What this does
Adds Becky and Ebru to the contributors list for CAP Static, so they're recognized for their work!

## Screenshot
![Screenshot 2024-02-12 at 4 00 20 PM](https://github.com/harvard-lil/capstone-static/assets/4039311/d80494a5-b151-4eb2-bdc0-c83fb61b570b)

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout update-contributors` to checkout this branch