### PR TITLE
Added hash change hooks to make deep links to paragraphs work.

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -371,6 +371,29 @@ export default class CapCase extends LitElement {
 					(data) => (this.caseMetadata = data),
 				),
 		);
+		window.addEventListener("hashchange", this.handleHashChange.bind(this));
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener("hashchange", this.handleHashChange.bind(this));
+	}
+
+	updated() {
+		// if a person navigates directly to a URL with a hash, handle it on load
+		this.handleHashChange();
+	}
+
+	handleHashChange() {
+		const hash = window.location.hash.substring(1); // remove the '#'
+		if (hash) {
+			const element = this.shadowRoot.getElementById(hash);
+			if (element) {
+				element.tabIndex = -1;
+				element.scrollIntoView();
+				element.focus();
+			}
+		}
 	}
 
 	getYearFromDate(str) {


### PR DESCRIPTION
Deep links to anchors for paragraphs weren't working. This uses the same technique we're using in the reporters page.

How to test:

Load a URL like http://localhost:5501/caselaw/?reporter=ill&volume=110&case=0035-01#p37. Observe that the page scrolls to that numbered paragraph.