### PR TITLE
fix: Container overflow

### DIFF
--- a/src/components/cap-stats.js
+++ b/src/components/cap-stats.js
@@ -20,9 +20,9 @@ class CapStats extends LitElement {
 				color: var(--color-white);
 				position: relative;
 				padding-block: var(--spacing-300);
-				padding-inline: calc(var(--spacing-475) * 1.5);
+				padding-inline: var(--spacing-475);
 
-				@media (min-width: 36rem) {
+				@media (min-width: 45rem) {
 					padding-block: calc(var(--spacing-300) * 1.125);
 					padding-inline: calc(var(--spacing-475) * 2);
 				}
@@ -52,7 +52,7 @@ class CapStats extends LitElement {
 				font-size: var(--font-size-150);
 				line-height: 1;
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					font-size: var(--font-size-225);
 				}
 			}
@@ -69,7 +69,7 @@ class CapStats extends LitElement {
 
 				border-bottom: var(--border-sm) solid var(--color-white);
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					border-bottom: var(--border-md) solid var(--color-white);
 				}
 			}
@@ -92,7 +92,7 @@ class CapStats extends LitElement {
 					background: var(--color-white);
 				}
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					font-size: 3rem;
 
 					&::before {
@@ -126,7 +126,7 @@ class CapStats extends LitElement {
 					background: var(--color-white);
 				}
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					&::before {
 						width: var(--border-md);
 					}
@@ -136,7 +136,7 @@ class CapStats extends LitElement {
 			.stat__number {
 				font-size: calc(var(--font-size-200) * 2);
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					font-size: 6rem;
 				}
 			}
@@ -148,7 +148,7 @@ class CapStats extends LitElement {
 				font-size: calc(var(--font-size-250) * 2);
 				grid-row: 1 / 3;
 
-				@media (min-width: 36rem) {
+				@media (min-width: 35rem) {
 					font-size: 9rem;
 				}
 			}


### PR DESCRIPTION
## What this does 
I noticed there is a subtle container overflow issue on the homepage, where the size of a content area overflows the total width of the viewport, and causes a horizontal scrollbar to be added to the page, shown in this screenshot:

<img width="611" alt="Screenshot 2024-02-15 at 2 17 54 PM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/432270ee-aeba-4737-9764-9923ecdd6bc9">

This only appeared at in-between sizes, between very small viewport sizes and large viewport sizes, and was caused by the cap-stats component that is shown in lieu of the interactive map at smaller sizes.

This update fixes the overflow by adjusting the inline padding on the cap-stats container. 

## Screenshots 

On desktop views, the padding stays the same:
<img width="762" alt="Screenshot 2024-02-15 at 1 55 43 PM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/666082e4-8bfe-401a-8138-2d9a003c9f56">

The inline padding previously applied at 35rem is now applied at 45rem (720px):
<img width="563" alt="Screenshot 2024-02-15 at 1 55 33 PM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/120e5ae8-23a7-401e-b5fb-e2a67a6ee897">

The inline padding for smaller mobile views than 720px has also been reduced:
<img width="446" alt="Screenshot 2024-02-15 at 1 55 19 PM" src="https://github.com/harvard-lil/capstone-static/assets/4039311/31be69de-8750-4c47-ad75-179747a14ea5">

In addition to these changes, I decreased a media query from 36rem to 35rem for consistency with other components. 

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of capstone-stone, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout fix-cap-stats-overflow` to checkout this branch