### PR TITLE
Hardcoded case ordinal crept back in somehow.

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -486,7 +486,7 @@ export default class CapCase extends LitElement {
 
 				const [reporter, volume, page] = pathComponents;
 				const newUrl = new URL(
-					`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}-01`,
+					`/caselaw/?reporter=${reporter}&volume=${volume}&case=${page.padStart(4, "0")}`,
 					window.location,
 				);
 				a.setAttribute("href", newUrl);


### PR DESCRIPTION
This probably happened during some merge... basically we used to hardcode the case ordinal `-01` back when the data didn't support us linking to multiple cases that started on the same page. 

Somehow that appendage crept back in, so we were seeing all citation links end with `-01` even though the real ordinal was already there, like, `-02-01`.

To test: All the citation links on http://127.0.0.1:5501/caselaw/?reporter=ill-app-2d&volume=45&case=0044-01 should work.