### PR TITLE
Change BUCKET_ROOT

### DIFF
--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -35,7 +35,7 @@
 		<script type="module" src="/components/cap-footer.js"></script>
 		<script type="module" src="/components/cap-nav.js"></script>
 		<script>
-			window.BUCKET_ROOT = "https://cap-redacted-demo.lil.tools";
+			window.BUCKET_ROOT = "https://static.case.law";
 		</script>
 
 		<link

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
 		<script type="module" src="components/cap-contact.js"></script>
 		<script type="module" src="components/cap-footer.js"></script>
 		<script>
-			window.BUCKET_ROOT = "https://cap-redacted-demo.lil.tools";
+			window.BUCKET_ROOT = "https://static.case.law";
 		</script>
 
 		<link

--- a/src/lib/data.test.js
+++ b/src/lib/data.test.js
@@ -10,7 +10,7 @@ import {
 	getBreadcrumbLinks,
 } from "./data.js";
 
-global.window = { BUCKET_ROOT: "https://cap-redacted-demo.lil.tools" };
+global.window = { BUCKET_ROOT: "https://static.case.law" };
 
 test("fetchJurisdictionsData fetches jurisdictions ", async (t) => {
 	await fetchJurisdictionsData((data) => {


### PR DESCRIPTION
This changes BUCKET_ROOT from a demo setting to its actual setting. Note that the new route doesn't exist yet, but will shortly; I want to break the demo deployment of this application for as short a time as possible. 

I plan to upload the complete export to another R2 bucket, then cut over the route from the demo bucket to that one.