### PR TITLE
Hack to prevent flash of unstyled content on 404 page.

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -88,15 +88,15 @@
 		<main id="main" class="l-interiorPage">
 			<header class="u-bg-gray-500 u-col-span-full">
 				<cap-page-header heading="Not Found.">
-					<p class="u-text-white u-text-serif">
+					<p class="u-text-white u-text-serif" style="visibility: hidden">
 						The Caselaw Access Project has updated and simplified our site to
 						provide long-term, unrestricted access to U.S. case law.
 					</p>
-					<p class="u-text-white u-text-serif">
+					<p class="u-text-white u-text-serif" style="visibility: hidden">
 						As part of this process we have deactivated portions of the site,
 						potentially including the page you were looking for.
 					</p>
-					<p class="u-text-white u-text-serif">
+					<p class="u-text-white u-text-serif" style="visibility: hidden">
 						If you have questions about the changes we have made, please let us
 						know at
 						<a class="u-link-purple" href="mailto:info@case.law"

--- a/src/components/cap-page-header.js
+++ b/src/components/cap-page-header.js
@@ -44,6 +44,7 @@ export class CapPageHeader extends LitElement {
 			}
 
 			::slotted(p) {
+				visibility: visible !important;
 				padding-top: var(--spacing-200);
 
 				@media (min-width: 35rem) {


### PR DESCRIPTION
Visit any page that 404s locally or on staging, for example, https://capstone-static.lil.tools/asdf.

If you watch carefully (force refresh as necessary), you will see the three paragraphs of text currently included in the 404 pages show up first, unstyled, and then the styled page snap into place. 

That's because "slots" are part of the normal "light" DOM rather than the shadow DOM: the browser renders them before taking care of all the fancy stuff that makes this page display correctly.

This PR adds a hack to prevent that behavior: the paragraphs are inserted with `visibility: hidden`, and then, once our web component act is in gear, CSS kicks in and reveals them.

Toggling the `visibility` seems to give a slightly better experience than toggling `display` from `none` to `block`: toggling `display` removes the elements from the layout, which affects heights, which causes the sticky footer to reposition; this is a little smoother, equally smooth/flashy as it is currently.