### PR TITLE
Redirect legacy URLs to new locations

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -3,69 +3,6 @@
 	<head
 		prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#"
 	>
-		<script>
-			// Check whether we should redirect to another URL
-
-			// Format the path for our checks
-			const referer = location.pathname.endsWith("/")
-				? location.pathname.slice(0, -1)
-				: location.pathname;
-			const refererPrefix = referer.split("/").slice(0, 2).join("/");
-			const urlParams = new URLSearchParams(window.location.search);
-
-			// If this is a request that originated from cite.case.law...
-			if (urlParams.get("src") === "cite.case.law"){
-
-				// ...attempt to parse it as an attempt to view caselaw.
-				const refererComponents = referer.split("/").filter( (entry) => { return entry.trim() != ''; });
-				if (refererComponents.length == 1) {
-					// Attempt to load a reporter
-					// previously: cite.case.law/<str:series_slug>/
-					window.location = `/caselaw/?reporter=${refererComponents[0]}`
-				} else if (refererComponents.length == 2) {
-					// Attempt to load a volume
-					// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/
-					window.location = `/caselaw/?reporter=${refererComponents[0]}&volume=${refererComponents[1]}`
-				}
-
-			} else {
-
-				// ...otherwise, see if we should redirect to one of the
-				// simplified site's new pages, or to the LIL museum.
-
-				// Simple redirects are an exact match.
-				const simpleRedirects = {
-					"/bulk/download": "/docs/#bulk-downloads",
-					"/exhibits/cite-grid":
-						"https://museum.lil.tools/archive/caselaw-access-project/cite-grid",
-					"/exhibits/limericks":
-						"https://museum.lil.tools/archive/caselaw-access-project/caselaw-limericks",
-					"/exhibits/witchcraft":
-						"https://museum.lil.tools/archive/caselaw-access-project/witchcraft",
-					"/exhibits/wordclouds":
-						"https://museum.lil.tools/archive/caselaw-access-project/california-wordclouds",
-					"/trends":
-						"https://museum.lil.tools/archive/caselaw-access-project/historical-trends",
-				};
-
-				// Glob redirects match a prefix.
-				const globRedirects = {
-					"/docs": "/docs/",
-					"/gallery": "/gallery/",
-				};
-
-				// Redirect if anything matches.
-				if (referer in simpleRedirects) {
-					window.location = simpleRedirects[referer];
-				} else if (refererPrefix in globRedirects) {
-					window.location = globRedirects[refererPrefix];
-				} else if (referer.startsWith("/labs/chronolawgic/timeline/")) {
-					// Chronologic timelines redirect to the LIL museum with a
-					// timeline-specific querystring,
-					window.location = `https://museum.lil.tools/archive/caselaw-access-project/chronolawgic?url=https://case.law${referer}`;
-				}
-			}
-		</script>
 		<title>404 Not Found | Caselaw Access Project</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -101,10 +38,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<script type="module" src="/components/cap-notification-banner.js"></script>
-		<script type="module" src="/components/cap-nav.js"></script>
-		<script type="module" src="/components/cap-page-header.js"></script>
-		<script type="module" src="/components/cap-footer.js"></script>
+		<script type="module" src="/components/cap-redirector.js"></script>
+		<script>
+			window.BUCKET_ROOT = "https://static.case.law";
+		</script>
 
 		<link
 			rel="apple-touch-icon"
@@ -148,30 +85,6 @@
 		<meta name="theme-color" content="#ffffff" />
 	</head>
 	<body>
-		<a href="#main" class="u-skipLink">Skip to main content</a>
-		<cap-notification-banner></cap-notification-banner>
-		<cap-nav></cap-nav>
-		<main id="main" class="l-interiorPage">
-			<header class="u-bg-gray-500 u-col-span-full">
-				<cap-page-header heading="Not Found.">
-					<p class="u-text-white u-text-serif" style="visibility: hidden">
-						The Caselaw Access Project has updated and simplified our site to
-						provide long-term, unrestricted access to U.S. case law.
-					</p>
-					<p class="u-text-white u-text-serif" style="visibility: hidden">
-						As part of this process we have deactivated portions of the site,
-						potentially including the page you were looking for.
-					</p>
-					<p class="u-text-white u-text-serif" style="visibility: hidden">
-						If you have questions about the changes we have made, please let us
-						know at
-						<a class="u-link-purple" href="mailto:info@case.law"
-							>info@case.law</a
-						>.
-					</p>
-				</cap-page-header>
-			</header>
-		</main>
-		<cap-footer></cap-footer>
+		<cap-redirector></cap-redirector>
 	</body>
 </html>

--- a/src/404.html
+++ b/src/404.html
@@ -16,8 +16,17 @@
 			// If this is a request that originated from cite.case.law...
 			if (urlParams.get("src") === "cite.case.law"){
 
-				// TODO
-				// ...attempt to parse it as an attempt to view caselaw
+				// ...attempt to parse it as an attempt to view caselaw.
+				const refererComponents = referer.split("/").filter( (entry) => { return entry.trim() != ''; });
+				if (refererComponents.length == 1) {
+					// Attempt to load a reporter
+					// previously: cite.case.law/<str:series_slug>/
+					window.location = `/caselaw/?reporter=${refererComponents[0]}`
+				} else if (refererComponents.length == 2) {
+					// Attempt to load a volume
+					// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/
+					window.location = `/caselaw/?reporter=${refererComponents[0]}&volume=${refererComponents[1]}`
+				}
 
 			} else {
 

--- a/src/404.html
+++ b/src/404.html
@@ -3,6 +3,60 @@
 	<head
 		prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#"
 	>
+		<script>
+			// Check whether we should redirect to another URL
+
+			// Format the path for our checks
+			const referer = location.pathname.endsWith("/")
+				? location.pathname.slice(0, -1)
+				: location.pathname;
+			const refererPrefix = referer.split("/").slice(0, 2).join("/");
+			const urlParams = new URLSearchParams(window.location.search);
+
+			// If this is a request that originated from cite.case.law...
+			if (urlParams.get("src") === "cite.case.law"){
+
+				// TODO
+				// ...attempt to parse it as an attempt to view caselaw
+
+			} else {
+
+				// ...otherwise, see if we should redirect to one of the
+				// simplified site's new pages, or to the LIL museum.
+
+				// Simple redirects are an exact match.
+				const simpleRedirects = {
+					"/bulk/download": "/docs/#bulk-downloads",
+					"/exhibits/cite-grid":
+						"https://museum.lil.tools/archive/caselaw-access-project/cite-grid",
+					"/exhibits/limericks":
+						"https://museum.lil.tools/archive/caselaw-access-project/caselaw-limericks",
+					"/exhibits/witchcraft":
+						"https://museum.lil.tools/archive/caselaw-access-project/witchcraft",
+					"/exhibits/wordclouds":
+						"https://museum.lil.tools/archive/caselaw-access-project/california-wordclouds",
+					"/trends":
+						"https://museum.lil.tools/archive/caselaw-access-project/historical-trends",
+				};
+
+				// Glob redirects match a prefix.
+				const globRedirects = {
+					"/docs": "/docs/",
+					"/gallery": "/gallery/",
+				};
+
+				// Redirect if anything matches.
+				if (referer in simpleRedirects) {
+					window.location = simpleRedirects[referer];
+				} else if (refererPrefix in globRedirects) {
+					window.location = globRedirects[refererPrefix];
+				} else if (referer.startsWith("/labs/chronolawgic/timeline/")) {
+					// Chronologic timelines redirect to the LIL museum with a
+					// timeline-specific querystring,
+					window.location = `https://museum.lil.tools/archive/caselaw-access-project/chronolawgic?url=https://case.law${referer}`;
+				}
+			}
+		</script>
 		<title>404 Not Found | Caselaw Access Project</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -24,7 +24,7 @@ export default class CapContentRouter extends LitElement {
 		const searchParams = new URLSearchParams(window.location.search);
 		const reporter = searchParams.get("reporter");
 		const volume = searchParams.get("volume");
-		const caseName = searchParams.get("case");
+		const casePath = searchParams.get("case");
 		const disambiguate = searchParams.get("disambiguate");
 		const cite = searchParams.get("cite");
 
@@ -35,11 +35,11 @@ export default class CapContentRouter extends LitElement {
 			></cap-disambiguate>`;
 		}
 
-		if (!!caseName && !!volume && !!reporter) {
+		if (!!casePath && !!volume && !!reporter) {
 			return html`<cap-case
 				reporter=${reporter}
 				volume=${volume}
-				case=${caseName}
+				case=${casePath}
 			></cap-case>`;
 		}
 

--- a/src/components/cap-disambiguate.js
+++ b/src/components/cap-disambiguate.js
@@ -57,15 +57,18 @@ export default class CapDisambiguate extends LitElement {
 		this.volume = volume;
 
 		fetchOr404(
-			fetchReporterData(reporter, (data) => {
-				this.reporterData = data;
-			}),
-			fetchVolumeData(reporter, volume, (data) => {
-				this.volumeData = data;
-			}),
-			fetchCasesList(reporter, volume, (data) => {
-				this.casesData = data;
-			}),
+			() =>
+				fetchReporterData(reporter, (data) => {
+					this.reporterData = data;
+				}),
+			() =>
+				fetchVolumeData(reporter, volume, (data) => {
+					this.volumeData = data;
+				}),
+			() =>
+				fetchCasesList(reporter, volume, (data) => {
+					this.casesData = data;
+				}),
 		);
 	}
 

--- a/src/components/cap-redirector.js
+++ b/src/components/cap-redirector.js
@@ -77,6 +77,22 @@ export default class CapRedirector extends LitElement {
 						}
 					}),
 				);
+			} else if (refererComponents.length == 4) {
+				// Attempt to load a single case using its case id.
+				// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/<str:page_number>/<int:case_id>/
+				const caseId = refererComponents[3];
+				fetchOr404(() =>
+					fetchCasesList(refererComponents[0], refererComponents[1], (data) => {
+						const targetCase = data.find((o) => o.id.toString() === caseId);
+						if (targetCase) {
+							const casePath = targetCase.file_name;
+							window.location = `/caselaw/?reporter=${refererComponents[0]}&volume=${refererComponents[1]}&case=${casePath}`;
+						} else {
+							// we know we're not redirecting
+							this.checkedRedirect = true;
+						}
+					}),
+				);
 			} else {
 				// we know we're not redirecting
 				this.checkedRedirect = true;

--- a/src/components/cap-redirector.js
+++ b/src/components/cap-redirector.js
@@ -45,15 +45,20 @@ export default class CapRedirector extends LitElement {
 			if (refererComponents.length == 1) {
 				// Attempt to load a reporter
 				// previously: cite.case.law/<str:series_slug>/
+				// Example: https://cite.case.law/ill-app/
 				window.location = `/caselaw/?reporter=${refererComponents[0]}`;
 			} else if (refererComponents.length == 2) {
 				// Attempt to load a volume
 				// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/
+				// Example: https://cite.case.law/ill-app/302/
 				window.location = `/caselaw/?reporter=${refererComponents[0]}&volume=${refererComponents[1]}`;
 			} else if (refererComponents.length == 3) {
 				// Attempt to load a single case using its page number.
 				// If multiple cases appear on the same page, show a disambiguation page instead.
 				// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/<str:page_number>
+				// Examples:
+				// single case - https://cite.case.law/ill-app/302/1/
+				// multiple cases - https://cite.case.law/ill-app/302/570
 				const page = refererComponents[2];
 				fetchOr404(() =>
 					fetchCasesList(refererComponents[0], refererComponents[1], (data) => {
@@ -80,6 +85,7 @@ export default class CapRedirector extends LitElement {
 			} else if (refererComponents.length == 4) {
 				// Attempt to load a single case using its case id.
 				// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/<str:page_number>/<int:case_id>/
+				// Example: https://cite.case.law/ill-app/302/570/3143810/
 				const caseId = refererComponents[3];
 				fetchOr404(() =>
 					fetchCasesList(refererComponents[0], refererComponents[1], (data) => {

--- a/src/components/cap-redirector.js
+++ b/src/components/cap-redirector.js
@@ -1,0 +1,127 @@
+import { LitElement, html, nothing } from "../lib/lit.js";
+
+import "./cap-notification-banner.js";
+import "./cap-nav.js";
+import "./cap-page-header.js";
+import "./cap-footer.js";
+
+export default class CapRedirector extends LitElement {
+	// Turn Shadow DOM off
+	// Generally discouraged: https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot
+	createRenderRoot() {
+		return this;
+	}
+
+	static properties = {
+		checkedRedirect: { type: Boolean },
+	};
+
+	constructor() {
+		super();
+		this.checkedRedirect = false;
+	}
+
+	async connectedCallback() {
+		super.connectedCallback();
+
+		// Check whether we should redirect to another URL
+
+		// Format the path for our checks
+		const referer = location.pathname.endsWith("/")
+			? location.pathname.slice(0, -1)
+			: location.pathname;
+		const refererPrefix = referer.split("/").slice(0, 2).join("/");
+		const urlParams = new URLSearchParams(window.location.search);
+
+		// If this is a request that originated from cite.case.law...
+		if (urlParams.get("src") === "cite.case.law") {
+			// ...attempt to parse it as an attempt to view caselaw.
+			const refererComponents = referer.split("/").filter((entry) => {
+				return entry.trim() != "";
+			});
+			if (refererComponents.length == 1) {
+				// Attempt to load a reporter
+				// previously: cite.case.law/<str:series_slug>/
+				window.location = `/caselaw/?reporter=${refererComponents[0]}`;
+			} else if (refererComponents.length == 2) {
+				// Attempt to load a volume
+				// previously: cite.case.law/<str:series_slug>/<str:volume_number_slug>/
+				window.location = `/caselaw/?reporter=${refererComponents[0]}&volume=${refererComponents[1]}`;
+			} else {
+				// we know we're not redirecting
+				this.checkedRedirect = true;
+			}
+		} else {
+			// ...otherwise, see if we should redirect to one of the
+			// simplified site's new pages, or to the LIL museum.
+
+			// Simple redirects are an exact match.
+			const simpleRedirects = {
+				"/bulk/download": "/docs/#bulk-downloads",
+				"/exhibits/cite-grid":
+					"https://museum.lil.tools/archive/caselaw-access-project/cite-grid",
+				"/exhibits/limericks":
+					"https://museum.lil.tools/archive/caselaw-access-project/caselaw-limericks",
+				"/exhibits/witchcraft":
+					"https://museum.lil.tools/archive/caselaw-access-project/witchcraft",
+				"/exhibits/wordclouds":
+					"https://museum.lil.tools/archive/caselaw-access-project/california-wordclouds",
+				"/trends":
+					"https://museum.lil.tools/archive/caselaw-access-project/historical-trends",
+			};
+
+			// Glob redirects match a prefix.
+			const globRedirects = {
+				"/docs": "/docs/",
+				"/gallery": "/gallery/",
+			};
+
+			// Redirect if anything matches.
+			if (referer in simpleRedirects) {
+				window.location = simpleRedirects[referer];
+			} else if (refererPrefix in globRedirects) {
+				window.location = globRedirects[refererPrefix];
+			} else if (referer.startsWith("/labs/chronolawgic/timeline/")) {
+				// Chronologic timelines redirect to the LIL museum with a
+				// timeline-specific querystring,
+				window.location = `https://museum.lil.tools/archive/caselaw-access-project/chronolawgic?url=https://case.law${referer}`;
+			}
+
+			// we know we're not redirecting
+			this.checkedRedirect = true;
+		}
+	}
+
+	render() {
+		if (this.checkedRedirect) {
+			return html`<a href="#main" class="u-skipLink">Skip to main content</a>
+				<cap-notification-banner></cap-notification-banner>
+				<cap-nav></cap-nav>
+				<main id="main" class="l-interiorPage">
+					<header class="u-bg-gray-500 u-col-span-full">
+						<cap-page-header heading="Not Found.">
+							<p class="u-text-white u-text-serif" style="visibility: hidden">
+								The Caselaw Access Project has updated and simplified our site
+								to provide long-term, unrestricted access to U.S. case law.
+							</p>
+							<p class="u-text-white u-text-serif" style="visibility: hidden">
+								As part of this process we have deactivated portions of the
+								site, potentially including the page you were looking for.
+							</p>
+							<p class="u-text-white u-text-serif" style="visibility: hidden">
+								If you have questions about the changes we have made, please let
+								us know at
+								<a class="u-link-purple" href="mailto:info@case.law"
+									>info@case.law</a
+								>.
+							</p>
+						</cap-page-header>
+					</header>
+				</main>
+				<cap-footer></cap-footer> `;
+		}
+		return nothing;
+	}
+}
+
+customElements.define("cap-redirector", CapRedirector);

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -54,10 +54,10 @@ export const fetchCasesList = async (reporter, volume, callback) => {
 export const fetchCaselawBody = async (
 	reporter,
 	volume,
-	caseName,
+	casePath,
 	callback,
 ) => {
-	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/html/${caseName}.html`;
+	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/html/${casePath}.html`;
 	const response = await fetch(url);
 	if (!response.ok) {
 		throw new Error("Fetch failed.");
@@ -68,10 +68,10 @@ export const fetchCaselawBody = async (
 export const fetchCaseMetadata = async (
 	reporter,
 	volume,
-	caseName,
+	casePath,
 	callback,
 ) => {
-	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/cases/${caseName}.json`;
+	const url = `${window.BUCKET_ROOT}/${reporter}/${volume}/cases/${casePath}.json`;
 	callback(await fetchJson(url)); //here return {} if it didn't fetch
 };
 


### PR DESCRIPTION
See ENG-667/ENG-586.

This static site will eventually go live at case.law. At that time, cite.case.law will be set to redirect to case.law. Many of the URLs we currently serve at those domains will no longer be available and will 404... but we'd like some legacy URLs to redirect to new content or to web archives of the original content.

This adds javascript redirects to this site's 404 page. We opted for this somewhat unusual strategy for several reasons:
- transparency: we like that the redirects are here in the source code, rather than, for instance, in Cloudflare page rules
- portability: we like that they'll work regardless of deployment and hosting strategy
- consistency: we knew we'd need javascript for at least some of them... so might as well use it for all of them

The redirects for case.law are simple:
- a few URLs redirect to the new docs
- a few URLs redirect to the new gallery page
- a small handful of URLs redirect to the LIL museum.

The redirects for cite.case.law are a little more intricate. In all cases, the goal is to redirect to the new version of the reporter, volume, or case that was served at the previous URL. Because of three reasons, the redirects for cases require a lookup and some logic:
- some legacy URLs used a CAP-specific "case ID", which is _not_ part of the paged-based URL structure of the current app
- sometimes multiple cases are on the same page of a given volume, which is not reflected in the legacy URL patterns, but _is_ reflected in the new URL patterns... so we have to look up whether to send visitors to the unique case that appears on a page, or rather to a disambiguation page that lets them select the case they are looking for from a set.
- we also need to be careful not to end up in a redirect loop, if an attempt to load a reporter/volume/case fails... in which case, the user should indeed see the 404 page.

I say "have to"... there's a world where we don't have to do that here, when redirecting, but rather, refactor the [content router](https://github.com/harvard-lil/capstone-static/blob/main/src/components/cap-content-router.js) and case/disambiguation components to handle all the logic.

That approach is likely more elegant, and was what I originally was planning to do... but this was easier and quicker. I wanted to get something out there that works... and we can refactor later, as we see fit. Refactoring could in theory improve the user experience by reducing the number of hops, as well as reduce the number of calls we make to R2, but in practice, I think the impact will be minimal.

I made this a component so that I could reuse the `fetchOr404` and `fetchCasesList` utilities. I did not feel like dealing with the Shadow DOM and rejiggering our styles to make that work, so I disabled it.

Finally, while reading through the code, I spotted two small things that I decided to fix, even though they are unrelated to the PR:
- there was a small bug in [cap-disambiguate.js](https://github.com/harvard-lil/capstone-static/pull/85/files#diff-c7a1cc9218daa12552dd8c904fb87684d04df95993c672ee0f895b596d4a2293): fetchOr404 needs to be passed arrow functions... otherwise requests are evaluated immediately, sequentially, rather than in parallel.
- i found the case "name" variable misleading: it refers to a page number and an index, rather than the case's name, so I switched it to "path".

To be discussed with Ben
------------------------
This code relies on redirects from cite.case.law being labeled as such, using any arbitrary query string. I went with [`?src=cite.case.law`](https://github.com/harvard-lil/capstone-static/pull/85/files#diff-404efef9db861d25f08f1fd48a39792d1b9d29d46c5c3e3932d7e0a19ce04d2dR40) in this draft... but in practice, it can be anything. We should pick something that you find appropriate.