### PR TITLE
Skip reporters without jurisdictions for now, on caselaw's index page.

### DIFF
--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -3,11 +3,14 @@ export const fetchJurisdictionsData = async (callback) => {
 	const data = await fetchJson(url);
 	const jurisdictions = {};
 	data.forEach((element) => {
-		const jurisdiction = element.jurisdictions[0].name_long;
-		if (!jurisdictions[jurisdiction]) {
-			jurisdictions[jurisdiction] = [];
+		// skip reporters without jurisdictions for now
+		if (element.jurisdictions[0]) {
+			const jurisdiction = element.jurisdictions[0].name_long;
+			if (!jurisdictions[jurisdiction]) {
+				jurisdictions[jurisdiction] = [];
+			}
+			jurisdictions[jurisdiction].push(element);
 		}
-		jurisdictions[jurisdiction].push(element);
 	});
 	callback(jurisdictions);
 };


### PR DESCRIPTION
It turns out not all reporters have jurisdictions: example, South Eastern Reporter 2d (se2d).

Skip them when munging the data for `/caselaw`, which prints a browseable list of reporters by jurisdiction.

We can discuss how to expose these reporters to users later.