### PR TITLE
Follow up on reporters that have multiple volumes with the same number

### DIFF
--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -125,8 +125,8 @@ export default class CapReporter extends LitElement {
 										html`<li>
 											<a
 												href="/caselaw/?reporter=${this
-													.reporter}&volume=${v.volume_number}"
-												>${v.volume_number}</a
+													.reporter}&volume=${v.volume_folder}"
+												>${v.volume_folder}</a
 											>
 										</li>`,
 								)}


### PR DESCRIPTION
See ENG-861

Uses the new [volume_folder](https://github.com/harvard-lil/capstone/pull/2208) field instead of volume_number, so that we point to unique volumes with non-unique numbers.

See `/caselaw/?reporter=nc` for an example: currently, you'll see `1 1 1`, all pointing to "North Carolina Reports (1778-2017) volume 1.", whose first case is "Ingram v. Hall, 1 N.C. 1 (1795):. After this change, you'll see `1 1-2 1-3`, each of which points to a distinct volume.



