### PR TITLE
Link to PDFs

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -114,7 +114,7 @@ export default class CapCase extends LitElement {
 			.pdf-link {
 				font-family: var(--font-sans-text);
 				text-align: center;
-				margin: var(--spacing-50) auto -1em;;
+				margin: var(--spacing-50) auto -1em;
 			}
 
 			/**/
@@ -452,15 +452,20 @@ export default class CapCase extends LitElement {
 		}
 	}
 
-	getPDFLink(){
-		if (this.caseMetadata.provenance.source === "Harvard"){
+	getPDFLink() {
+		if (this.caseMetadata.provenance.source === "Harvard") {
 			return html`
 				<div class="pdf-link">
-					<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf#page=${this.caseMetadata.first_page_order}"> View scanned PDF</a>
+					<a
+						href="${window.BUCKET_ROOT}/${this.reporter}/${this
+							.volume}.pdf#page=${this.caseMetadata.first_page_order}"
+					>
+						View scanned PDF</a
+					>
 				</div>
 			`;
 		}
-		return nothing
+		return nothing;
 	}
 
 	removeLink = (a) => {

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -109,6 +109,14 @@ export default class CapCase extends LitElement {
 				font-style: italic;
 			}
 
+			/* PDF link */
+
+			.pdf-link {
+				font-family: var(--font-sans-text);
+				text-align: center;
+				margin: var(--spacing-50) auto -1em;;
+			}
+
 			/**/
 			/* Styles that apply to the injected HTML */
 			/**/
@@ -444,6 +452,17 @@ export default class CapCase extends LitElement {
 		}
 	}
 
+	getPDFLink(){
+		if (this.caseMetadata.provenance.source === "Harvard"){
+			return html`
+				<div class="pdf-link">
+					<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf#page=${this.caseMetadata.first_page_order}"> View scanned PDF</a>
+				</div>
+			`;
+		}
+		return nothing
+	}
+
 	removeLink = (a) => {
 		a.replaceWith(a.innerHTML);
 	};
@@ -527,6 +546,7 @@ export default class CapCase extends LitElement {
 					<div class="metadata">
 						<div class="case-name">${this.caseMetadata.name}</div>
 					</div>
+					${this.getPDFLink()}
 					<!--section.casebody -->
 					${unsafeHTML(this.caseBody)}
 				</div>

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -110,11 +110,15 @@ export default class CapVolume extends LitElement {
 		);
 	}
 
-	getPDFLink(){
-		if (this.casesData[0].provenance.source === "Harvard"){
-			return html`<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"> View scanned PDF.</a>`;
+	getPDFLink() {
+		if (this.casesData[0].provenance.source === "Harvard") {
+			return html`<a
+				href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"
+			>
+				View scanned PDF.</a
+			>`;
 		}
-		return nothing
+		return nothing;
 	}
 
 	render() {
@@ -137,8 +141,7 @@ export default class CapVolume extends LitElement {
 							<p class="volume__subHeading">
 								${this.reporterData.full_name}
 								(${this.reporterData.start_year}-${this.reporterData.end_year})
-								volume ${this.volume}.
-								${this.getPDFLink()}
+								volume ${this.volume}. ${this.getPDFLink()}
 							</p>
 						</hgroup>
 						<ul class="volume__caseList">

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -110,6 +110,13 @@ export default class CapVolume extends LitElement {
 		);
 	}
 
+	getPDFLink(){
+		if (this.casesData[0].provenance.source === "Harvard"){
+			return html`<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"> View scanned PDF.</a>`;
+		}
+		return nothing
+	}
+
 	render() {
 		if (
 			!isEmpty(this.casesData) &&
@@ -131,7 +138,7 @@ export default class CapVolume extends LitElement {
 								${this.reporterData.full_name}
 								(${this.reporterData.start_year}-${this.reporterData.end_year})
 								volume ${this.volume}.
-								<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"> View scanned PDF.</a>
+								${this.getPDFLink()}
 							</p>
 						</hgroup>
 						<ul class="volume__caseList">

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -131,6 +131,7 @@ export default class CapVolume extends LitElement {
 								${this.reporterData.full_name}
 								(${this.reporterData.start_year}-${this.reporterData.end_year})
 								volume ${this.volume}.
+								<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"> View scanned PDF.</a>
 							</p>
 						</hgroup>
 						<ul class="volume__caseList">


### PR DESCRIPTION
See ENG-692.

This adds a link to download a volume's PDF, when one is available, in the same place as on the old site:

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/61e69987-7c32-43bf-acde-2e38a77fe730)

It adds a link to individual cases in the PDF as well, with very basic styling:
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/05fe3790-c643-49e4-bc1e-b002649aa81a)

To see volumes with PDFs, try Alabama and North Carolina. To see volumes with PDFs, try the latest ones from Alaska.

It's just a first pass at this ticket: we probably want to follow up with additional PRs. TBD.