### PR TITLE
Add more links to downloads

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -29,7 +29,46 @@ export default class CapCase extends LitElement {
 			/**/
 
 			.case__navigation {
-				padding-block-end: var(--spacing-400);
+				max-width: 80%;
+				margin-inline: auto;
+
+				@media (min-width: 65rem) {
+					padding-block-end: var(--spacing-200);
+				}
+			}
+
+			.case__downloadLinks {
+				margin-block-start: var(--spacing-100);
+				font-family: var(--font-sans-text);
+
+				@media (min-width: 35rem) {
+					font-size: var(--font-size-175);
+				}
+
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: space-evenly;
+				align-content: space-evenly;
+			}
+
+			.case__downloadLinks a {
+				color: var(--color-gray-500);
+				cursor: pointer;
+				background: none;
+				border: 2px solid var(--color-gray-500);
+				font-weight: 600;
+				font-size: var(--font-size-100);
+				text-align: center;
+				text-transform: uppercase;
+				padding: calc(var(--spacing-125) / 2);
+				text-decoration: none;
+				margin: var(--spacing-50);
+				flex-grow: 1;
+			}
+
+			.case__downloadLinks a:hover {
+				color: var(--color-blue-400);
+				border-color: var(--color-blue-400);
 			}
 
 			/* .case-container */
@@ -61,7 +100,7 @@ export default class CapCase extends LitElement {
 				font-size: 0.9em;
 				font-family: var(--font-serif-titling);
 				text-align: center;
-				padding: 2em 2em 0;
+				padding: 0 2em 0;
 				max-width: 83.33333%;
 				margin: auto;
 			}
@@ -84,6 +123,7 @@ export default class CapCase extends LitElement {
 				line-height: 1.4em;
 				padding: 0;
 				margin: 0;
+				margin-bottom: var(--spacing-50);
 			}
 
 			.case-header .decision-date,
@@ -111,14 +151,6 @@ export default class CapCase extends LitElement {
 				display: block;
 				margin: 0.5em;
 				font-style: italic;
-			}
-
-			/* PDF link */
-
-			.pdf-link {
-				font-family: var(--font-sans-text);
-				text-align: center;
-				margin: var(--spacing-50) auto -1em;
 			}
 
 			/**/
@@ -462,14 +494,11 @@ export default class CapCase extends LitElement {
 	getPDFLink() {
 		if (this.caseMetadata.provenance.source === "Harvard") {
 			return html`
-				<div class="pdf-link">
-					<a
-						href="${window.BUCKET_ROOT}/${this.reporter}/${this
-							.volume}.pdf#page=${this.caseMetadata.first_page_order}"
-					>
-						View scanned PDF</a
-					>
-				</div>
+				<a
+					href="${window.BUCKET_ROOT}/${this.reporter}/${this
+						.volume}.pdf#page=${this.caseMetadata.first_page_order}"
+					>View scanned PDF</a
+				>
 			`;
 		}
 		return nothing;
@@ -554,6 +583,15 @@ export default class CapCase extends LitElement {
 							this.caseMetadata.citations[0].cite,
 						)}
 					></cap-breadcrumb>
+					<div class="case__downloadLinks">
+						${this.getPDFLink()}
+						<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}/cases/${this.case}.json"
+							>Download case metadata</a
+						>
+						<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}/html/${this.case}.html"
+							>Download case HTML</a
+						>
+					</div>
 				</div>
 				<cap-caselaw-layout>
 					<div class="case-container">
@@ -571,7 +609,6 @@ export default class CapCase extends LitElement {
 						<div class="metadata">
 							<div class="case-name">${this.caseMetadata.name}</div>
 						</div>
-						${this.getPDFLink()}
 						<!--section.casebody -->
 						${unsafeHTML(this.caseBody)}
 					</div>

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -585,10 +585,14 @@ export default class CapCase extends LitElement {
 					></cap-breadcrumb>
 					<div class="case__downloadLinks">
 						${this.getPDFLink()}
-						<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}/cases/${this.case}.json"
+						<a
+							href="${window.BUCKET_ROOT}/${this.reporter}/${this
+								.volume}/cases/${this.case}.json"
 							>Download case metadata</a
 						>
-						<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}/html/${this.case}.html"
+						<a
+							href="${window.BUCKET_ROOT}/${this.reporter}/${this
+								.volume}/html/${this.case}.html"
 							>Download case HTML</a
 						>
 					</div>

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -14,8 +14,8 @@ export default class CapContentRouter extends LitElement {
 				flex: 0 0 58.33333%;
 				max-width: 58.33333%;
 				margin: auto;
-				padding-top: 2.5rem;
-				padding-bottom: 3rem;
+				padding-top: var(--spacing-250);
+				padding-bottom: var(--spacing-500);
 			}
 		`,
 	];

--- a/src/components/cap-content-router.js
+++ b/src/components/cap-content-router.js
@@ -11,11 +11,14 @@ export default class CapContentRouter extends LitElement {
 		css`
 			cap-case {
 				display: block;
-				flex: 0 0 58.33333%;
-				max-width: 58.33333%;
 				margin: auto;
 				padding-top: var(--spacing-250);
 				padding-bottom: var(--spacing-500);
+
+				@media (min-width: 65rem) {
+					flex: 0 0 58.33333%;
+					max-width: 58.33333%;
+				}
 			}
 		`,
 	];

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -76,7 +76,7 @@ export default class CapJurisdictions extends LitElement {
 				padding: calc(var(--spacing-125) / 2);
 			}
 
-			jurisdictions__button a:hover {
+			.jurisdictions__button a:hover {
 				color: var(--color-blue-400);
 				border-color: var(--color-blue-400);
 			}

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -60,6 +60,27 @@ export default class CapJurisdictions extends LitElement {
 				font-family: var(--font-serif);
 			}
 
+			.jurisdictions__button {
+				margin-top: var(--spacing-75);
+			}
+
+			.jurisdictions__button a {
+				color: var(--color-gray-600);
+				cursor: pointer;
+				background: none;
+				border: 2px solid var(--color-gray-600);
+				font-weight: 700;
+				font-size: var(--font-size-100);
+				text-transform: uppercase;
+				width: fit-content;
+				padding: calc(var(--spacing-125) / 2);
+			}
+
+			jurisdictions__button a:hover {
+				color: var(--color-blue-400);
+				border-color: var(--color-blue-400);
+			}
+
 			.jurisdictions__main {
 				grid-column: 1 / -1;
 				padding-inline: var(--spacing-500);
@@ -159,6 +180,12 @@ export default class CapJurisdictions extends LitElement {
 						<cap-page-header heading="Read Caselaw" theme="light" icon="none">
 							<p class="jurisdictions__description">
 								Browse all volumes of the Caselaw Access Project below.
+							</p>
+							<p class="jurisdictions__description">
+								Or, <a href="${window.BUCKET_ROOT}">download our data</a>.
+							</p>
+							<p class="jurisdictions__button">
+								<a href="/docs/#bulk-downloads">Learn more about bulk data</a>
 							</p>
 						</cap-page-header>
 					</header>

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -80,6 +80,14 @@ export default class CapReporter extends LitElement {
 				font-weight: 500;
 			}
 
+			.reporter__downloadLinks {
+				margin-block-start: var(--spacing-150);
+			}
+
+			.reporter__downloadLinks a {
+				font-weight: 400;
+			}
+
 			.reporter__volumeList {
 				margin-block-start: var(--spacing-150);
 				display: block;
@@ -116,6 +124,30 @@ export default class CapReporter extends LitElement {
 								(${this.reporterData.start_year}-${this.reporterData.end_year}).
 							</p>
 						</hgroup>
+						<div class="reporter__downloadLinks">
+							<p>
+								Download
+								<a href="${window.BUCKET_ROOT}/${this.reporter}/">bulk data</a>.
+							</p>
+						</div>
+						<div class="reporter__downloadLinks">
+							<p>
+								Download
+								<a
+									href="${window.BUCKET_ROOT}/${this
+										.reporter}/ReporterMetadata.json"
+									>reporter metadata</a
+								>.
+							</p>
+							<p>
+								Download
+								<a
+									href="${window.BUCKET_ROOT}/${this
+										.reporter}/VolumesMetadata.json"
+									>volumes metadata</a
+								>.
+							</p>
+						</div>
 						<ul class="reporter__volumeList">
 							<p class="reporter__volumeTitle">Volume number:</p>
 							${this.volumesData

--- a/src/components/cap-reporter.js
+++ b/src/components/cap-reporter.js
@@ -164,8 +164,7 @@ export default class CapReporter extends LitElement {
 								)}
 						</ul>
 					</div>
-					<cap-caselaw-layout> </cap-caselaw-layout
-				></cap-caselaw-layout>
+				</cap-caselaw-layout>
 			`;
 		} else {
 			return nothing;

--- a/src/components/cap-volume.js
+++ b/src/components/cap-volume.js
@@ -83,6 +83,20 @@ export default class CapVolume extends LitElement {
 				font-weight: 500;
 			}
 
+			.volume__downloadLinks {
+				margin-block-start: var(--spacing-150);
+			}
+
+			.volume__downloadLinks a {
+				font-weight: 400;
+			}
+
+			.volume__caseListHeading {
+				margin-block-start: var(--spacing-200);
+				font-size: var(--font-size-175);
+				font-weight: 600;
+			}
+
 			.volume__caseList {
 				margin-block-start: var(--spacing-150);
 				display: block;
@@ -110,13 +124,16 @@ export default class CapVolume extends LitElement {
 		);
 	}
 
-	getPDFLink() {
+	downloadPDF() {
 		if (this.casesData[0].provenance.source === "Harvard") {
-			return html`<a
-				href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf"
-			>
-				View scanned PDF.</a
-			>`;
+			return html` <div class="volume__downloadLinks">
+				<p>
+					View
+					<a href="${window.BUCKET_ROOT}/${this.reporter}/${this.volume}.pdf">
+						scanned PDF</a
+					>.
+				</p>
+			</div>`;
 		}
 		return nothing;
 	}
@@ -141,9 +158,33 @@ export default class CapVolume extends LitElement {
 							<p class="volume__subHeading">
 								${this.reporterData.full_name}
 								(${this.reporterData.start_year}-${this.reporterData.end_year})
-								volume ${this.volume}. ${this.getPDFLink()}
+								volume ${this.volume}.
 							</p>
 						</hgroup>
+						${this.downloadPDF()}
+						<div class="volume__downloadLinks">
+							<p>
+								Download
+								<a href="${window.BUCKET_ROOT}/${this.reporter}/">bulk data</a>.
+							</p>
+							<p>
+								Download
+								<a
+									href="${window.BUCKET_ROOT}/${this.reporter}/${this
+										.volume}/VolumeMetadata.json"
+									>volume metadata</a
+								>.
+							</p>
+							<p>
+								Download
+								<a
+									href="${window.BUCKET_ROOT}/${this.reporter}/${this
+										.volume}/CasesMetadata.json"
+									>cases metadata</a
+								>.
+							</p>
+						</div>
+						<h2 class="volume__caseListHeading">Cases</h2>
 						<ul class="volume__caseList">
 							${this.casesData.map(
 								(c) =>

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -102,20 +102,30 @@ const fetchJson = async (url) => {
 	return await response.json();
 };
 
-export const getBreadcrumbLinks = (reporterData, volume) => {
+export const getBreadcrumbLinks = (reporterData, volume, caseCitation) => {
 	const reporterLink = {
 		url: `/caselaw/?reporter=${reporterData.slug}`,
 		name: `Reporter ${reporterData.short_name}`,
 	};
 
-	if (volume) {
-		return [
-			reporterLink,
-			{
+	const volumeLink = volume
+		? {
 				url: `/caselaw/?reporter=${reporterData.slug}&volume=${volume}`,
 				name: `Volume ${volume}`,
-			},
-		];
+			}
+		: null;
+
+	const caseLink = caseCitation
+		? {
+				url: `.`,
+				name: caseCitation,
+			}
+		: null;
+
+	if (caseCitation) {
+		return [reporterLink, volumeLink, caseLink];
+	} else if (volumeLink) {
+		return [reporterLink, volumeLink];
 	}
 
 	return [reporterLink];


### PR DESCRIPTION
See ENG-692.

This PR adds links directly to the bulk data in a number of places. The styling may not be up to our standards, but is the best I could manage today.

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/041a0ae5-0a8b-411d-85a5-12a0cca555cc)

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/be92e890-dc3e-464b-b218-e0b309e3ddec)

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/a5181592-ae1d-4aa9-821a-f58e632982dc)

![image](https://github.com/harvard-lil/capstone-static/assets/11020492/fab03f0e-a7ba-4256-a084-17fd84857cef)

