### PR TITLE
Fix in-page anchors; make consistent.

### DIFF
--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -389,7 +389,7 @@ export default class CapCase extends LitElement {
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
-				await new Promise(r => setTimeout(r, 100));
+				await new Promise((r) => setTimeout(r, 100));
 				element.tabIndex = -1;
 				element.scrollIntoView();
 				element.focus();

--- a/src/components/cap-case.js
+++ b/src/components/cap-case.js
@@ -384,11 +384,12 @@ export default class CapCase extends LitElement {
 		this.handleHashChange();
 	}
 
-	handleHashChange() {
+	async handleHashChange() {
 		const hash = window.location.hash.substring(1); // remove the '#'
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
+				await new Promise(r => setTimeout(r, 100));
 				element.tabIndex = -1;
 				element.scrollIntoView();
 				element.focus();

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -131,7 +131,7 @@ export default class CapJurisdictions extends LitElement {
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
-				await new Promise(r => setTimeout(r, 100));
+				await new Promise((r) => setTimeout(r, 100));
 				element.tabIndex = -1;
 				element.scrollIntoView();
 				element.focus();

--- a/src/components/cap-jurisdictions.js
+++ b/src/components/cap-jurisdictions.js
@@ -126,11 +126,12 @@ export default class CapJurisdictions extends LitElement {
 	 potentially problematic when we have to render case HTML, so I started 
 	 using this pattern here.
 	*/
-	handleHashChange() {
+	async handleHashChange() {
 		const hash = window.location.hash.substring(1); // remove the '#'
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
+				await new Promise(r => setTimeout(r, 100));
 				element.tabIndex = -1;
 				element.scrollIntoView();
 				element.focus();

--- a/src/templates/cap-about-page.js
+++ b/src/templates/cap-about-page.js
@@ -185,7 +185,7 @@ export class CapAboutPage extends LitElement {
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
-				await new Promise(r => setTimeout(r, 100));
+				await new Promise((r) => setTimeout(r, 100));
 				element.tabIndex = -1;
 				element.scrollIntoView();
 				element.focus();

--- a/src/templates/cap-about-page.js
+++ b/src/templates/cap-about-page.js
@@ -180,14 +180,15 @@ export class CapAboutPage extends LitElement {
 	 potentially problematic when we have to render case HTML, so I started
 	 using this pattern here.
 	*/
-	handleHashChange() {
+	async handleHashChange() {
 		const hash = window.location.hash.substring(1); // remove the '#'
 		if (hash) {
 			const element = this.shadowRoot.getElementById(hash);
 			if (element) {
-				// wait a beat for things to draw.
-				window.requestAnimationFrame(() => {});
-				window.requestAnimationFrame(() => element.scrollIntoView());
+				await new Promise(r => setTimeout(r, 100));
+				element.tabIndex = -1;
+				element.scrollIntoView();
+				element.focus();
 			}
 		}
 	}


### PR DESCRIPTION
See ENG-719.

Shadow DOM + in-page anchors + time to render long lists -> needing to give things some time to render before trying to scroll into place.

Don't even get me started.