### PR TITLE
Add noscript tags

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -38,10 +38,14 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/components/cap-redirector.js"></script>
 		<script>
 			window.BUCKET_ROOT = "https://static.case.law";
 		</script>
+		<script type="module" src="/components/cap-nav.js"></script>
+		<script type="module" src="/components/cap-page-header.js"></script>
+		<script type="module" src="/components/cap-footer.js"></script>
 
 		<link
 			rel="apple-touch-icon"

--- a/src/404.html
+++ b/src/404.html
@@ -38,7 +38,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/components/cap-redirector.js"></script>
 		<script>
 			window.BUCKET_ROOT = "https://static.case.law";

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -33,6 +33,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/templates/cap-about-page.js"></script>
 
 		<link
@@ -96,6 +97,7 @@
 		<!-- End Matomo Code -->
 	</head>
 	<body>
+
 		<cap-about-page></cap-about-page>
 	</body>
 </html>

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -33,7 +33,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/templates/cap-about-page.js"></script>
 
 		<link
@@ -97,7 +100,6 @@
 		<!-- End Matomo Code -->
 	</head>
 	<body>
-
 		<cap-about-page></cap-about-page>
 	</body>
 </html>

--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -31,7 +31,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/components/cap-content-router.js"></script>
 		<script type="module" src="/components/cap-footer.js"></script>
 		<script type="module" src="/components/cap-nav.js"></script>

--- a/src/caselaw/index.html
+++ b/src/caselaw/index.html
@@ -31,6 +31,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/components/cap-content-router.js"></script>
 		<script type="module" src="/components/cap-footer.js"></script>
 		<script type="module" src="/components/cap-nav.js"></script>

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -80,7 +80,10 @@
 			content="images/favicon/mstile-150x150.png"
 		/>
 		<meta name="theme-color" content="#ffffff" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/templates/cap-docs-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -80,6 +80,7 @@
 			content="images/favicon/mstile-150x150.png"
 		/>
 		<meta name="theme-color" content="#ffffff" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/templates/cap-docs-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/gallery/index.html
+++ b/src/gallery/index.html
@@ -25,6 +25,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/templates/cap-gallery-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/gallery/index.html
+++ b/src/gallery/index.html
@@ -25,7 +25,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/templates/cap-gallery-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="components/cap-map.js"></script>
 		<script type="module" src="components/cap-notification-banner.js"></script>
 		<script type="module" src="components/cap-nav.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="components/cap-map.js"></script>
 		<script type="module" src="components/cap-notification-banner.js"></script>
 		<script type="module" src="components/cap-nav.js"></script>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -42,6 +42,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/templates/cap-privacy-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -42,7 +42,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/templates/cap-privacy-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/terms/index.html
+++ b/src/terms/index.html
@@ -33,7 +33,10 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
-		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
+		<noscript
+			>JavaScript needs to be enabled to view the Caselaw Access Project
+			website.</noscript
+		>
 		<script type="module" src="/templates/cap-terms-page.js"></script>
 		<!-- Matomo -->
 		<script>

--- a/src/terms/index.html
+++ b/src/terms/index.html
@@ -33,6 +33,7 @@
 		<meta property="og:type" content="article" />
 
 		<link href="/css/global.css" rel="stylesheet" />
+		<noscript>JavaScript needs to be enabled to view the Caselaw Access Project website.</noscript>
 		<script type="module" src="/templates/cap-terms-page.js"></script>
 		<!-- Matomo -->
 		<script>


### PR DESCRIPTION
## What This Does
Adds a `noscript` tag to each page of the Caselaw Access website. 

## Screenshots 
On pages with JavaScript enabled, any additional text will be hidden: 
![Screenshot 2024-03-12 at 10 46 01 AM](https://github.com/harvard-lil/capstone-static/assets/4039311/d6e10ce0-fd8a-4c9f-96e4-dec570d2bda8)

If JavaScript is disabled, this text will be visible: 
![Screenshot 2024-03-12 at 10 56 53 AM](https://github.com/harvard-lil/capstone-static/assets/4039311/acc86995-db9f-438d-8b24-f3c5918fa386)

## How to Test
If you are using a Chromium-based browser, these are the steps I took to test this out: 

- Open Chrome Dev Tools. (On a Mac, this is typically CMD-Option-I)
- Depending on your operating system, press one of the following to open the Chrome developer tools Command Menu:
  - On Windows or Linux, Control+Shift+P
  - On MacOS, Command+Shift+P
 - Start typing JavaScript, select Disable JavaScript, and then press Enter to run the command.
 - Reload the page.
 - JavaScript will be disabled in the window until its re-enabled or the window is closed.