### PR TITLE
Change navbar link to CL advanced search page

### DIFF
--- a/src/data/nav.js
+++ b/src/data/nav.js
@@ -1,7 +1,7 @@
 export const navLinks = [
 	{
 		name: "Search",
-		path: "https://www.courtlistener.com/",
+		path: "https://www.courtlistener.com/opinion/",
 	},
 	{
 		name: "Caselaw",


### PR DESCRIPTION
As mentioned in harvard-lil/capstone#2211, I think this page might be a better destination for folks, since it highlights our search engine, coverage, etc much better.

Either way is great though, so I trust your judgement, but thought I'd suggest it. 