### PR TITLE
Fix map numbers

### DIFF
--- a/src/components/cap-map.js
+++ b/src/components/cap-map.js
@@ -150,6 +150,10 @@ export class CapMap extends LitElement {
 		return mapping;
 	}
 
+	getFormattedNumber(number) {
+		return number.toLocaleString();
+	}
+
 	render() {
 		return html`
 			<div class="mapRegion">
@@ -166,19 +170,18 @@ export class CapMap extends LitElement {
 								: "State and Federal Totals"}
 						</h3>
 						<p class="infoBox__text">
-							${this.activeStats.caseCount}<br /><span
+							${this.getFormattedNumber(this.activeStats.caseCount)}<br /><span
 								class="infoBox__textDescriptor"
 								>Unique cases</span
 							>
 						</p>
 						<p class="infoBox__text">
-							${this.activeStats.reporterCount}<br /><span
-								class="infoBox__textDescriptor"
-								>Reporters</span
-							>
+							${this.getFormattedNumber(
+								this.activeStats.reporterCount,
+							)}<br /><span class="infoBox__textDescriptor">Reporters</span>
 						</p>
 						<p class="infoBox__text">
-							${this.activeStats.pageCount}<br /><span
+							${this.getFormattedNumber(this.activeStats.pageCount)}<br /><span
 								class="infoBox__textDescriptor"
 								>Pages scanned</span
 							>
@@ -186,22 +189,19 @@ export class CapMap extends LitElement {
 
 						<h3 class="infoBox__heading">Federal Totals</h3>
 						<p class="infoBox__text">
-							${nationalCaselawStats.total.caseCount}<br /><span
-								class="infoBox__textDescriptor"
-								>Unique cases</span
-							>
+							${this.getFormattedNumber(
+								nationalCaselawStats.total.caseCount,
+							)}<br /><span class="infoBox__textDescriptor">Unique cases</span>
 						</p>
 						<p class="infoBox__text">
-							${nationalCaselawStats.total.reporterCount}<br /><span
-								class="infoBox__textDescriptor"
-								>Reporters</span
-							>
+							${this.getFormattedNumber(
+								nationalCaselawStats.total.reporterCount,
+							)}<br /><span class="infoBox__textDescriptor">Reporters</span>
 						</p>
 						<p class="infoBox__text">
-							${nationalCaselawStats.total.pageCount}<br /><span
-								class="infoBox__textDescriptor"
-								>Pages scanned</span
-							>
+							${this.getFormattedNumber(
+								nationalCaselawStats.total.pageCount,
+							)}<br /><span class="infoBox__textDescriptor">Pages scanned</span>
 						</p>
 					</div>
 

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -59,12 +59,12 @@ export const mapAbbreviations = [
 ];
 
 export const nationalCaselawStats = {
-	total: {
+	state: {
 		caseCount: 6930777,
 		reporterCount: 612,
 		pageCount: 36357668,
 	},
-	state: {
+	total: {
 		caseCount: 1842484,
 		reporterCount: 75,
 		pageCount: 10409741,


### PR DESCRIPTION
## What this does 
- Flip-flops the overall stats for the map, which were displaying the wrong numbers for national vs state totals 
- Adds a small formatting function to properly add commas to all of the numbers being displayed in the map

Closes ENG-769

## Screenshot
The new map should now properly display both the right numbers and formatted in the right way for US numbers:
![Screenshot of fixed map](https://github.com/harvard-lil/capstone-static/assets/4039311/ebf1e2b5-9ea3-4ab9-a5e1-57788b029fce)

