### PR TITLE
Add interstitial to search nav link.

### DIFF
--- a/src/components/cap-nav.js
+++ b/src/components/cap-nav.js
@@ -7,6 +7,32 @@ class CapNav extends LitElement {
 	static styles = [
 		baseStyles,
 		css`
+			.searchInterstitial {
+				max-inline-size: min(90vw, 60ch);
+				max-block-size: min(80vh, 100%);
+				max-block-size: min(80dvb, 100%);
+				overflow: hidden;
+				background-color: var(--color-beige);
+				position: fixed;
+				margin: auto;
+				inset: 0;
+				padding: 0;
+				padding-inline: var(--spacing-500);
+				padding-block-start: var(--spacing-300);
+				padding-block-end: var(--spacing-300);
+				border: 0;
+			}
+			.searchInterstitial::backdrop {
+				background-color: var(--color-gray-600);
+				opacity: 0.7;
+			}
+			.searchInterstitial * + * {
+				margin-block-start: var(--spacing-100);
+
+				@media (min-width: 35rem) {
+					margin-block-start: var(--spacing-200);
+				}
+			}
 			.header {
 				position: relative;
 			}
@@ -144,67 +170,102 @@ class CapNav extends LitElement {
 		}
 	}
 
+	_openSearchInterstitial(event) {
+		event.preventDefault();
+
+		const searchInterstitial = this.shadowRoot.querySelector(
+			".searchInterstitial",
+		);
+		searchInterstitial.showModal();
+	}
+
 	render() {
 		return html`
-			<header class="header">
-				<nav class="nav">
-					<a href="/">
-						<cap-logo></cap-logo>
-						<span class="u-visuallyHidden">Caselaw Access Project</span></a
-					>
-
-					<button
-						class="nav__mobileMenuToggle"
-						aria-haspopup="menu"
-						aria-expanded="false"
-						@click="${this._handleMenuToggle}"
-					>
-						<span class="u-visuallyHidden"> Menu </span>
-
-						<svg
-							class="nav__mobileMenuIcon"
-							aria-hidden="true"
-							width="25"
-							height="18"
-							viewBox="0 0 25 18"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
+			<div>
+				<dialog class="searchInterstitial">
+					<h2>Search at CourtListener</h2>
+					<p>Goodbye for now!</p>
+					<p>
+						All use restrictions for the Caselaw Access Project's data have
+						officially been lifted. To consolidate efforts and make space for
+						future projects at the Library Innovation Lab, we have partnered
+						with our good friends at CourtListener to provide search for the
+						corpus.
+					</p>
+					<p>
+						<a href="https://www.courtlistener.com/opinion/">
+							Proceed to CourtListener
+						</a>
+					</p>
+				</dialog>
+				<header class="header">
+					<nav class="nav">
+						<a href="/">
+							<cap-logo></cap-logo>
+							<span class="u-visuallyHidden">Caselaw Access Project</span></a
 						>
-							<path
-								class="nav__mobileMenuPath nav__mobileMenuPath--top"
-								fill-rule="evenodd"
-								clip-rule="evenodd"
-								d="M8.74228e-08 0.999998C1.35705e-07 0.447713 0.447716 -2.14643e-06 1 -2.09815e-06L24 -8.74228e-08C24.5523 -3.91405e-08 25 0.447715 25 1V1C25 1.55228 24.5523 2 24 2L1 2C0.447715 2 3.91405e-08 1.55228 8.74228e-08 0.999998V0.999998Z"
-								fill="currentColor"
-							/>
-							<path
-								class="nav__mobileMenuPath nav__mobileMenuPath--middle"
-								fill-rule="evenodd"
-								clip-rule="evenodd"
-								d="M8.74228e-08 9C1.35705e-07 8.44771 0.447716 8 1 8L24 8C24.5523 8 25 8.44772 25 9V9C25 9.55228 24.5523 10 24 10L1 10C0.447715 10 3.91405e-08 9.55228 8.74228e-08 9V9Z"
-								fill="currentColor"
-							/>
-							<path
-								class="nav__mobileMenuPath nav__mobileMenuPath--bottom"
-								fill-rule="evenodd"
-								clip-rule="evenodd"
-								d="M8.74228e-08 17C1.35705e-07 16.4477 0.447716 16 1 16L24 16C24.5523 16 25 16.4477 25 17V17C25 17.5523 24.5523 18 24 18L1 18C0.447715 18 3.91405e-08 17.5523 8.74228e-08 17V17Z"
-								fill="currentColor"
-							/>
-						</svg>
-					</button>
 
-					<ul class="nav__list">
-						${navLinks.map((link) => {
-							return html`
-								<li class="nav__item" tab>
-									<a class="nav__link" href="${link.path}">${link.name}</a>
-								</li>
-							`;
-						})}
-					</ul>
-				</nav>
-			</header>
+						<button
+							class="nav__mobileMenuToggle"
+							aria-haspopup="menu"
+							aria-expanded="false"
+							@click="${this._handleMenuToggle}"
+						>
+							<span class="u-visuallyHidden"> Menu </span>
+
+							<svg
+								class="nav__mobileMenuIcon"
+								aria-hidden="true"
+								width="25"
+								height="18"
+								viewBox="0 0 25 18"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									class="nav__mobileMenuPath nav__mobileMenuPath--top"
+									fill-rule="evenodd"
+									clip-rule="evenodd"
+									d="M8.74228e-08 0.999998C1.35705e-07 0.447713 0.447716 -2.14643e-06 1 -2.09815e-06L24 -8.74228e-08C24.5523 -3.91405e-08 25 0.447715 25 1V1C25 1.55228 24.5523 2 24 2L1 2C0.447715 2 3.91405e-08 1.55228 8.74228e-08 0.999998V0.999998Z"
+									fill="currentColor"
+								/>
+								<path
+									class="nav__mobileMenuPath nav__mobileMenuPath--middle"
+									fill-rule="evenodd"
+									clip-rule="evenodd"
+									d="M8.74228e-08 9C1.35705e-07 8.44771 0.447716 8 1 8L24 8C24.5523 8 25 8.44772 25 9V9C25 9.55228 24.5523 10 24 10L1 10C0.447715 10 3.91405e-08 9.55228 8.74228e-08 9V9Z"
+									fill="currentColor"
+								/>
+								<path
+									class="nav__mobileMenuPath nav__mobileMenuPath--bottom"
+									fill-rule="evenodd"
+									clip-rule="evenodd"
+									d="M8.74228e-08 17C1.35705e-07 16.4477 0.447716 16 1 16L24 16C24.5523 16 25 16.4477 25 17V17C25 17.5523 24.5523 18 24 18L1 18C0.447715 18 3.91405e-08 17.5523 8.74228e-08 17V17Z"
+									fill="currentColor"
+								/>
+							</svg>
+						</button>
+
+						<ul class="nav__list">
+							<li class="nav__item" tab>
+								<a
+									class="nav__link"
+									@click="${this._openSearchInterstitial}"
+									href="https://www.courtlistener.com/opinion/"
+									>Search</a
+								>
+							</li>
+							${navLinks.map((link) => {
+								return html`
+									<li class="nav__item" tab>
+										<a class="nav__link" href="${link.path}">${link.name}</a>
+									</li>
+								`;
+							})}
+						</ul>
+					</nav>
+				</header>
+			</div>
 		`;
 	}
 }

--- a/src/components/cap-nav.js
+++ b/src/components/cap-nav.js
@@ -186,7 +186,7 @@ class CapNav extends LitElement {
 					<h2>Search at CourtListener</h2>
 					<p>Goodbye for now!</p>
 					<p>
-						All use restrictions for the Caselaw Access Project's data have
+						All use restrictions for the Caselaw Access Project’s data have
 						officially been lifted. To consolidate efforts and make space for
 						future projects at the Library Innovation Lab, we have partnered
 						with our good friends at CourtListener to provide search for the

--- a/src/data/nav.js
+++ b/src/data/nav.js
@@ -1,9 +1,5 @@
 export const navLinks = [
 	{
-		name: "Search",
-		path: "https://www.courtlistener.com/opinion/",
-	},
-	{
 		name: "Caselaw",
 		path: "/caselaw/",
 	},


### PR DESCRIPTION
See ENG-750.

Currently, we link straight to the advanced search page at CourtListener in the main navigation and in the footer.

This PR switches the header link to toggle an interstitial instead, explaining what we are up to. Per discussion with Greg: since there is a lot of copy, the interstitial waits for the user to click through, rather than auto-redirecting after a few seconds. (There are usability plusses and minuses to both styles, but I think this is the correct choice.)

I didn't do anything fancy with the styles. TBD if the link wants to look more prominent: if it does, I would love for the particulars of the design to be dictated rather than improvised :-)

Never visited, triggered by mouse
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/f128523c-8e05-4b58-97d6-3932c9811343)

Already visited once, triggered by keyboard
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/95903809-a9d2-48f5-a990-23f140e676ec)

Mobile 
![image](https://github.com/harvard-lil/capstone-static/assets/11020492/e87293ba-7614-4fbb-b041-7cf1f766f9a8)

Because `dialog` is magic, all the keyboard stuff JUST WORKS: focus is trapped inside the modal, focus sets to the link on toggle, escape dismisses and focus returns to the nav link, et voila.

I decided not to include it redundantly in the page footer; seem unnecessary.